### PR TITLE
Add lazy minimal promise. Promises/A+ interoperable, but not fully compliant

### DIFF
--- a/Promise.js
+++ b/Promise.js
@@ -1,0 +1,144 @@
+var async = require('./async');
+
+module.exports = Promise;
+
+function Promise(resolver) {
+	this._fork = resolver;
+}
+
+Promise.of = of;
+Promise.resolve = resolve;
+Promise.reject = reject;
+
+function of(x) {
+	return new ResolvedPromise(x);
+}
+
+function resolve(x) {
+	return x instanceof Promise ? x : of(x);
+}
+
+function reject(x) {
+	return new RejectedPromise(x);
+}
+
+Promise.prototype._resolver = function(resolve, reject) {
+	var self = this;
+
+	function _resolve(x) {
+		this._value = x;
+		self._fork = self._resolved;
+		resolve(x);
+	}
+
+	function _reject(x) {
+		this._value = x;
+		self._fork = self._rejected;
+		reject(x);
+	}
+
+	try {
+		this._fork(_resolve, _reject);
+	} catch (e) {
+		_reject(e);
+	}
+};
+
+Promise.prototype._resolved = function(resolve) {
+	resolve(this._value);
+};
+
+Promise.prototype._rejected = function(_, reject) {
+	reject(this._value);
+};
+
+Promise.prototype.done = function(f, r) {
+	var p = this;
+	async(function() {
+		p._resolver(function(x) {
+			if(typeof f === 'function') {
+				f(x);
+			}
+		}, function(e) {
+			if(typeof r === 'function') {
+				r(e);
+			} else {
+				throw e;
+			}
+		});
+	});
+};
+
+Promise.prototype.map = function(f) {
+	var prev = this;
+	return new Promise(function(resolve, reject) {
+		prev._resolver(function(x) {
+			resolve(f(x));
+		}, reject);
+	});
+};
+
+Promise.prototype.flatMap = function(f) {
+	var prev = this;
+	return new Promise(function(resolve, reject) {
+		prev._resolver(function(x) {
+			f(x)._resolver(resolve, reject);
+		}, reject);
+	});
+};
+
+Promise.prototype.ap = function(promise) {
+	return this.flatMap(function(f) {
+		return promise.map(f);
+	});
+};
+
+Promise.prototype.then = function(f, r) {
+	var next = typeof f === 'function' ? this.flatMap(function(x) {
+		if(x instanceof Promise) {
+			return x.then(f);
+		}
+
+		if(Object(x) !== x) {
+			return resolve(f(x));
+		}
+
+		var then = x.then;
+		if(typeof then === 'function') {
+			return new Promise(function(resolve, reject) {
+				then.call(x, resolve, reject);
+			});
+		}
+
+		return resolve(f(x));
+	}) : this;
+
+	return typeof r === 'function' ? next.catch(r) : next;
+};
+
+Promise.prototype.catch = function(f) {
+	var prev = this;
+	return new Promise(function(resolve) {
+		prev._resolver(resolve, function(e) {
+			resolve(f(e));
+		});
+	});
+};
+
+function ResolvedPromise(x) {
+	this._value = x;
+}
+
+ResolvedPromise.prototype = Object.create(Promise.prototype);
+ResolvedPromise.prototype._resolver = function(resolve) {
+	resolve(this._value);
+};
+
+function RejectedPromise(x) {
+	this._value = x;
+}
+
+RejectedPromise.prototype = Object.create(Promise.prototype);
+RejectedPromise.prototype._resolver = function(_, reject) {
+	reject(this._value);
+};

--- a/test/Promise-test.js
+++ b/test/Promise-test.js
@@ -1,0 +1,188 @@
+var buster = require('buster');
+var assert = buster.assert;
+var refute = buster.refute;
+
+var Promise = require('../Promise');
+
+var sentinel = { value: 'sentinel' };
+var other = { value: 'other' };
+
+function assertp(assert, done, p1, p2) {
+	p1.done(function(x) {
+		p2.done(function(y) {
+			assert(x, y);
+			done();
+		});
+	});
+}
+
+function assertEquals(done, p1, p2) {
+	assertp(assert.equals, done, p1, p2);
+}
+
+function assertSame(done, p1, p2) {
+	assertp(assert.same, done, p1, p2);
+}
+
+buster.testCase('Promise', {
+
+	'done': {
+		'should initiate resolver': function(done) {
+			new Promise(function(resolve, reject) {
+				assert.isFunction(resolve);
+				assert.isFunction(reject);
+				done();
+			}).done();
+		}
+	},
+
+	'of': {
+		'should create a promise for x': function(done) {
+			Promise.of(sentinel).done(function(x) {
+				assert.same(x, sentinel);
+				done();
+			});
+		}
+	},
+
+	'map': {
+		'should satisfy identity': function(done) {
+			// u.map(function(a) { return a; })) ~= u
+			var u = Promise.of(sentinel);
+			assertSame(done, u.map(function(x) { return x; }), u);
+		},
+
+		'should satisfy composition': function(done) {
+			//u.map(function(x) { return f(g(x)); }) ~= u.map(g).map(f)
+			function f(x) { return x + 'f'; }
+			function g(x) { return x + 'g'; }
+
+			var u = Promise.of('e');
+
+			assertEquals(done,
+				u.map(function(x) { return f(g(x)); }),
+				u.map(g).map(f)
+			);
+		}
+	},
+
+	'flatMap': {
+		'should satisfy associativity': function(done) {
+			// m.flatMap(f).flatMap(g) ~= m.flatMap(function(x) { return f(x).flatMap(g); })
+			function f(x) { return Promise.of(x + 'f'); }
+			function g(x) { return Promise.of(x + 'g'); }
+
+			var m = Promise.of('m');
+
+			assertEquals(done,
+				m.flatMap(function(x) { return f(x).flatMap(g); }),
+				m.flatMap(f).flatMap(g)
+			);
+		}
+	},
+
+	'ap': {
+		'should satisfy identity': function(done) {
+			// P.of(function(a) { return a; }).ap(v) ~= v
+			var v = Promise.of(sentinel);
+			assertSame(done, Promise.of(function(x) { return x; }).ap(v), v);
+		},
+
+		'should satisfy composition': function(done) {
+			//P.of(function(f) { return function(g) { return function(x) { return f(g(x))}; }; }).ap(u).ap(v).ap(w) ~= u.ap(v.ap(w))
+			var u = Promise.of(function(x) { return 'u' + x; });
+			var v = Promise.of(function(x) { return 'v' + x; });
+			var w = Promise.of('w');
+
+			assertEquals(done, Promise.of(function(f) {
+					return function(g) {
+						return function(x) {
+							return f(g(x));
+						};
+					};
+				}).ap(u).ap(v).ap(w),
+				u.ap(v.ap(w))
+			);
+		},
+
+		'should satisfy homomorphism': function(done) {
+			//P.of(f).ap(P.of(x)) ~= P.of(f(x)) (homomorphism)
+			function f(x) { return x + 'f'; }
+			var x = 'x';
+			assertEquals(done, Promise.of(f).ap(Promise.of(x)), Promise.of(f(x)));
+		},
+
+		'should satisfy interchange': function(done) {
+			// u.ap(a.of(y)) ~= a.of(function(f) { return f(y); }).ap(u)
+			function f(x) { return x + 'f'; }
+
+			var u = Promise.of(f);
+			var y = 'y';
+
+			assertEquals(done,
+				u.ap(Promise.of(y)),
+				Promise.of(function(f) { return f(y); }).ap(u)
+			);
+		}
+	},
+
+	'then': {
+		'should forward result when callback is null': function(done) {
+			new Promise(function(resolve) {
+				resolve(sentinel);
+			}).then(null).then(function(x) {
+				assert.same(x, sentinel);
+			}).done(done, buster.fail);
+		},
+
+		'should forward callback result to next callback': function(done) {
+			new Promise(function(resolve) {
+				resolve(other);
+			}).then(function() {
+				return sentinel;
+			}).then(function(x) {
+				assert.same(x, sentinel);
+			}).done(done, buster.fail);
+		},
+
+		'should forward undefined': function(done) {
+			new Promise(function(resolve) {
+				resolve(sentinel);
+			}).then(function() {
+				// intentionally return undefined
+			}).then(function(x) {
+				refute.defined(x);
+			}).done(done, buster.fail);
+		},
+
+		'should forward undefined rejection value': function(done) {
+			new Promise(function(_, reject) {
+				reject(sentinel);
+			}).then(buster.fail, function() {
+				// intentionally return undefined
+			}).then(function(x) {
+				refute.defined(x);
+			}).done(done, buster.fail);
+		},
+
+		'should forward promised callback result value to next callback': function(done) {
+			new Promise(function(resolve) {
+				resolve(other);
+			}).then(function() {
+				return Promise.resolve(sentinel);
+			}).then(function(x) {
+				assert.same(x, sentinel);
+			}).done(done, buster.fail);
+		},
+
+		'should switch from callbacks to errbacks when callback returns a rejection': function(done) {
+			new Promise(function(resolve) {
+				resolve(other);
+			}).then(function() {
+				return Promise.reject(sentinel);
+			}).then(null, function(x) {
+				assert.same(x, sentinel);
+			}).done(done, buster.fail);
+		}
+	}
+});


### PR DESCRIPTION
Mostly for discussion.  This is a lazy monadic promise with map, flatMap, and ap.  It also has a then() that recursively unwraps promises and thenables, so is Promises/A+ interoperable.

It's lazy in that the promise doesn't run its resolve until done() is called the first time.  So, promises must be consumed via then, before any work is done.  That also forces people to handle errors since done will throw loudly on any unhandled rejection (thus crashing node).
