### PR TITLE
Add promise

### DIFF
--- a/Promise.js
+++ b/Promise.js
@@ -1,4 +1,4 @@
-var async = require('./async');
+var async = require('./lib/async');
 
 module.exports = Promise;
 
@@ -87,6 +87,10 @@ Promise.prototype.flatMap = function(f) {
 	});
 };
 
+Promise.prototype.flatten = function() {
+	return this.flatMap(identity);
+};
+
 Promise.prototype.ap = function(promise) {
 	return this.flatMap(function(f) {
 		return promise.map(f);
@@ -99,15 +103,13 @@ Promise.prototype.then = function(f, r) {
 			return x.then(f);
 		}
 
-		if(Object(x) !== x) {
-			return resolve(f(x));
-		}
-
-		var then = x.then;
-		if(typeof then === 'function') {
-			return new Promise(function(resolve, reject) {
-				then.call(x, resolve, reject);
-			});
+		if(Object(x) === x) {
+			var then = x.then;
+			if(typeof then === 'function') {
+				return new Promise(function(resolve, reject) {
+					then.call(x, resolve, reject);
+				}).then(f);
+			}
 		}
 
 		return resolve(f(x));
@@ -142,3 +144,5 @@ RejectedPromise.prototype = Object.create(Promise.prototype);
 RejectedPromise.prototype._resolver = function(_, reject) {
 	reject(this._value);
 };
+
+function identity(x) { return x; }

--- a/test/Promise-test.js
+++ b/test/Promise-test.js
@@ -36,12 +36,76 @@ buster.testCase('Promise', {
 		}
 	},
 
+	'catch': {
+		'should be called for errors': function(done) {
+			Promise.of(other).map(function() {
+				throw sentinel;
+			}).catch(function(e) {
+				assert.same(e, sentinel);
+			}).done(done, buster.fail);
+		},
+
+		'should recover from error': {
+			'when it returns a non-promise value': function(done) {
+				Promise.of(other).map(function() {
+					throw sentinel;
+				}).catch(function(x) {
+					return x;
+				}).map(function(x) {
+					assert.same(x, sentinel);
+				}).done(done, buster.fail);
+			},
+
+			'when it returns a fulfilled promise value': function(done) {
+				Promise.of(other).map(function() {
+					throw sentinel;
+				}).catch(function(x) {
+					return Promise.of(x);
+				}).flatten().map(function(x) {
+					assert.same(x, sentinel);
+				}).done(done, buster.fail);
+			}
+		},
+
+		'should propagate error': {
+			'when it throws': function(done) {
+				Promise.of().map(function() {
+					throw other;
+				}).catch(function() {
+					throw sentinel;
+				}).catch(function(x) {
+					assert.same(x, sentinel);
+				}).done(done, buster.fail);
+			},
+
+			'when it returns a rejected promise': function(done) {
+				Promise.of().map(function() {
+					throw other;
+				}).catch(function() {
+					return Promise.reject(sentinel);
+				}).flatten().catch(function(x) {
+					assert.same(x, sentinel);
+				}).done(done, buster.fail);
+			}
+		}
+	},
+
 	'of': {
-		'should create a promise for x': function(done) {
-			Promise.of(sentinel).done(function(x) {
-				assert.same(x, sentinel);
-				done();
-			});
+		'should create a promise for x': {
+			'when x is a non-promise value': function(done) {
+				Promise.of(sentinel).done(function(x) {
+					assert.same(x, sentinel);
+					done();
+				});
+			},
+
+			'when x is a promise': function(done) {
+				var x = Promise.of();
+				Promise.of(x).done(function(y) {
+					assert.same(x, y);
+					done();
+				});
+			}
 		}
 	},
 


### PR DESCRIPTION
Mostly for discussion. This is a lazy monadic promise with map, flatMap, and ap. It also has a then() that recursively unwraps promises and thenables, so is _almost_ Promises/A+ interoperable (see below).

It's lazy in that the promise doesn't run its resolve until done() is called the first time. So, promises must be consumed via `done`, before any work is done. That also forces people to handle errors since `done` will throw loudly on any unhandled rejection (thus crashing node).

The fact that `then` is lazy causes Promises/A+ and ES6 interop issues.  If assimilation relied on `done` instead of `then`, it would all work out.  Similarly, if there is a clean way to make this Promise impl's `then` eager, it would probably also work out, but that seems less desirable.

Another option might be to say this thing is not a Promise, and remove `then`.
