### PR TITLE
Add takeUntil

### DIFF
--- a/lib/combinators/filter.js
+++ b/lib/combinators/filter.js
@@ -7,6 +7,8 @@ var promise = require('../promises');
 var step = require('../step');
 
 var when = promise.when;
+var raceIndex = promise.raceIndex;
+
 var Yield = step.Yield;
 var End = step.End;
 var Pair = step.Pair;
@@ -15,6 +17,7 @@ var yieldPair = step.yieldPair;
 var init = {};
 
 exports.filter = filter;
+exports.takeUntil = takeUntil;
 exports.take = take;
 exports.takeWhile = takeWhile;
 exports.distinct = distinct;
@@ -22,6 +25,8 @@ exports.distinctBy = distinctBy;
 
 /**
  * Retain only items matching a predicate
+ * stream:                           -12345678-
+ * filter(x => x % 2 === 0, stream): --2-4-6-8-
  * @param {function(x:*):boolean} p filtering predicate called for each item
  * @param {Stream} stream stream to filter
  * @returns {Stream} stream containing only items for which predicate returns truthy
@@ -41,6 +46,8 @@ function filterNext(p, stepper, state) {
 }
 
 /**
+ * stream:          -abcd-
+ * take(2, stream): -ab
  * @param {function(x:*):boolean} p
  * @param {Stream} stream stream from which to take
  * @returns {Stream} stream containing items up to, but not including, the
@@ -48,15 +55,18 @@ function filterNext(p, stepper, state) {
  */
 function takeWhile(p, stream) {
 	var stepper = stream.step;
+	var dispose = stream.dispose;
 	return stream.beget(function(s) {
 		return when(function (i) {
 			return i.done || p(i.value) ? i
-				: new End(i.time, i.value, s.state);
+				: new End(i.time, i.value, s.state, dispose);
 		}, when(stepper, s));
 	}, stream.state);
 }
 
 /**
+ * stream:                        -123451234-
+ * takeWhile(x => x < 5, stream): -1234
  * @param {Number} n
  * @param {Stream} stream stream from which to take
  * @returns {Stream} stream containing at most the first n items from this stream
@@ -77,17 +87,74 @@ function take(n, stream) {
 }
 
 /**
- * Remove adjacent duplicates: [a,b,b,c,b] -> [a,b,c,b]
- * @param {Stream} stream stream from which to omit adjacent duplicates
- * @returns {Stream} stream with no adjacent duplicates using === to
- *  recognize duplicates
+ * stream:                    -a-b-c-d-e-f-g
+ * signal:                    -------x
+ * takeUntil(signal, stream): -a-b-c-
+ * @param {Stream} signal retain only events in stream before the first
+ * event in signal
+ * @param {Stream} stream events to retain
+ * @returns {Stream} new stream containing only events that occur before
+ * the first event in signal.
+ */
+function takeUntil(signal, stream) {
+	return stream.beget(stepTakeUntil, initTakeUntil(signal, stream));
+}
+
+function stepTakeUntil(s) {
+	return s.time === Infinity ? stepTakeUntilSignal(s) : stepTakeUntilTime(s);
+}
+
+function stepTakeUntilTime(s) {
+	return when(function(i) {
+		return i.time < s.time ? i.withState(updateTakeUntilState(s, i.state))
+			: new End(s.time, i.value, s.state, s.stream.dispose);
+	}, when(s.stream.step, s.state));
+}
+
+function stepTakeUntilSignal (s) {
+	return raceIndex(function (i, index) {
+		return index === 0 ? stepTakeUntilTime(updateTakeUntilTime(s, i.time))
+			: i.withState(updateTakeUntilState(s, i.state));
+	}, [getSignal(s), when(s.stream.step, s.state)]);
+}
+
+function getSignal (s) {
+	return s.until === void 0 ? when(s.signal.step, s.signal.state) : s.until;
+}
+
+function initTakeUntil (signal, stream) {
+	return new TakeUntil(void 0, Infinity, signal, stream, stream.state);
+}
+
+function updateTakeUntilState(s, newState) {
+	return new TakeUntil(s.until, s.time, s.signal, s.stream, newState);
+}
+
+function updateTakeUntilTime(s, t) {
+	return new TakeUntil(void 0, t, void 0, s.stream, s.state);
+}
+
+function TakeUntil(until, time, signal, stream, state) {
+	this.until = until, this.time = time, this.signal = signal;
+	this.stream = stream; this.state = state;
+}
+
+
+/**
+ * Remove adjacent duplicates, using === to detect duplicates
+ * stream:           -abbcd-
+ * distinct(stream): -ab-cd-
+ * @param {?function(a:*, b:*):boolean} equals optional function to compare items.
+ * @returns {Stream} stream with no adjacent duplicates
  */
 function distinct(stream) {
 	return distinctBy(same, stream);
 }
 
 /**
- * Remove adjacent duplicates: [a,b,b,c,b] -> [a,b,c,b]
+ * Remove adjacent duplicates using the provided equals function to detect duplicates
+ * stream:           -abbcd-
+ * distinct(stream): -ab-cd-
  * @param {?function(a:*, b:*):boolean} equals optional function to compare items.
  * @param {Stream} stream stream from which to omit adjacent duplicates
  * @returns {Stream} stream with no adjacent duplicates

--- a/most.js
+++ b/most.js
@@ -194,12 +194,14 @@ Stream.prototype.tap = function(f) {
 
 var filter = require('./lib/combinators/filter');
 var filterStream = filter.filter;
+var takeUntil = filter.takeUntil;
 var take = filter.take;
 var takeWhile = filter.takeWhile;
 var distinctSame = filter.distinct;
 var distinctBy = filter.distinctBy;
 
 exports.filter     = filterStream;
+exports.takeUntil  = takeUntil;
 exports.take       = take;
 exports.takeWhile  = takeWhile;
 exports.distinct   = distinctSame;
@@ -207,6 +209,8 @@ exports.distinctBy = distinctBy;
 
 /**
  * Retain only items matching a predicate
+ * stream:                           -12345678-
+ * filter(x => x % 2 === 0, stream): --2-4-6-8-
  * @param {function(x:*):boolean} p filtering predicate called for each item
  * @returns {Stream} stream containing only items for which predicate returns truthy
  */
@@ -215,7 +219,23 @@ Stream.prototype.filter = function(p) {
 };
 
 /**
- * @param {Number} n
+ * stream:                    -a-b-c-d-e-f-g-
+ * signal:                    -------x
+ * takeUntil(signal, stream): -a-b-c-
+ * @param {Stream} signal retain only events in stream before the first
+ * event in signal
+ * @param {Stream} stream events to retain
+ * @returns {Stream} new stream containing only events that occur before
+ * the first event in signal.
+ */
+Stream.prototype.takeUntil = function(signal) {
+	return takeUntil(signal, this);
+};
+
+/**
+ * stream:          -abcd-
+ * take(2, stream): -ab
+ * @param {Number} n take up to this many events
  * @returns {Stream} stream containing at most the first n items from this stream
  */
 Stream.prototype.take = function(n) {
@@ -223,6 +243,8 @@ Stream.prototype.take = function(n) {
 };
 
 /**
+ * stream:                        -123451234-
+ * takeWhile(x => x < 5, stream): -1234
  * @param {function(x:*):boolean} p
  * @returns {Stream} stream containing items up to, but not including, the
  * first item for which p returns falsy.
@@ -232,7 +254,9 @@ Stream.prototype.takeWhile = function(p) {
 };
 
 /**
- * Remove adjacent duplicates: [a,b,b,c,b] -> [a,b,c,b]
+ * Remove adjacent duplicates
+ * stream:           -abbcd-
+ * distinct(stream): -ab-cd-
  * @param {?function(a:*, b:*):boolean} equals optional function to compare items.
  * @returns {Stream} stream with no adjacent duplicates
  */

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -3,12 +3,23 @@ var expect = require('buster').expect;
 
 var filter = require('../lib/combinators/filter');
 var build = require('../lib/combinators/build');
+var reduce = require('../lib/combinators/reduce').reduce;
+var observe = require('../lib/combinators/observe').observe;
+var Stream = require('../lib/Stream');
+
 var iterate = build.iterate;
 var repeat = build.repeat;
-var Stream = require('../lib/Stream');
+
+var step = require('../lib/step');
+var Yield = step.Yield;
+var End = step.End;
 
 var sentinel = { value: 'sentinel' };
 var other = { value: 'other' };
+
+function identity(x) {
+	return x;
+}
 
 describe('filter', function() {
 	it('should return a stream containing only allowed items', function() {
@@ -22,12 +33,50 @@ describe('filter', function() {
 	});
 });
 
+describe('takeUntil', function() {
+	it('should only contain events earlier than signal', function() {
+
+		var times = [0, 1, 2, 3, 4, 5];
+		var steps = times.reduceRight(function(step, t) {
+			return new Yield(t, t, step);
+		}, new End(times[times.length-1] + 1));
+
+		var stream = new Stream(identity, steps);
+		var signal = new Stream(identity, new Yield(3));
+
+		return observe(function(x) {
+			expect(x).toBeLessThan(3);
+		}, filter.takeUntil(signal, stream));
+	});
+
+	it('should dispose source stream', function() {
+
+		var times = [0, 1, 2];
+		var steps = times.reduceRight(function(step, t) {
+			return new Yield(t, t, step);
+		}, new End(times[times.length-1] + 1));
+
+		var dispose = this.spy();
+		var stream = new Stream(identity, steps, void 0, dispose);
+		var signal = new Stream(identity, new Yield(1));
+
+		return observe(function() {},
+			filter.takeUntil(signal, stream))
+			.then(function() {
+				expect(dispose).toHaveBeenCalledOnce();
+			});
+
+	});
+});
+
 describe('take', function() {
 	it('should take first n elements', function () {
-		return filter.take(2, repeat(sentinel))
-			.reduce(function (count) {
+		var stream = filter.take(2, repeat(sentinel));
+
+		return reduce(function (count) {
 				return count + 1;
-			}, 0).then(function (count) {
+			}, 0, stream)
+			.then(function (count) {
 				expect(count).toBe(2);
 			});
 	});
@@ -35,15 +84,17 @@ describe('take', function() {
 
 describe('takeWhile', function() {
 	it('should take elements until condition becomes false', function() {
-		return filter.takeWhile(function(x) {
+		var stream = filter.takeWhile(function (x) {
 			return x < 10;
-		}, iterate(function(x) {
+		}, iterate(function (x) {
 			return x + 1;
-		}, 0))
-			.reduce(function(count, x) {
+		}, 0));
+
+		return reduce(function(count, x) {
 				expect(x).toBeLessThan(10);
 				return count + 1;
-			}, 0).then(function(count) {
+			}, 0, stream)
+			.then(function(count) {
 				expect(count).toBe(10);
 			});
 	});
@@ -53,11 +104,12 @@ describe('takeWhile', function() {
 describe('filter', function() {
 
 	it('should return a stream with adjacent duplicates removed', function() {
-		return filter.distinct(Stream.from([1, 2, 2, 3, 4, 4]))
-			.reduce(function(a, x) {
+		var stream = filter.distinct(Stream.from([1, 2, 2, 3, 4, 4]));
+		return reduce(function(a, x) {
 				a.push(x);
 				return a;
-			}, []).then(function(a) {
+			}, [], stream)
+			.then(function(a) {
 				expect(a).toEqual([1,2,3,4]);
 			});
 	});
@@ -68,14 +120,15 @@ describe('distinctBy', function() {
 
 	it('should use provided comparator to remove adjacent duplicates', function() {
 		function eq(a, b) {
-			return a.toLowerCase() === b.toLocaleLowerCase();
+			return a.toLowerCase() === b.toLowerCase();
 		}
 
-		return filter.distinctBy(eq, Stream.from(['a', 'b', 'B', 'c', 'D', 'd']))
-			.reduce(function(a, x) {
+		var stream = filter.distinctBy(eq, Stream.from(['a', 'b', 'B', 'c', 'D', 'd']));
+		return reduce(function(a, x) {
 				a.push(x);
 				return a;
-			}, []).then(function(a) {
+			}, [], stream)
+			.then(function(a) {
 				expect(a).toEqual(['a', 'b', 'c', 'D']);
 			});
 	});


### PR DESCRIPTION
Keep items earlier than a signal from another stream.   Add takeUntil unit tests and cleanup up unit tests in same file.  Improve jsdoc for filter-related public APIs.

Close #26
