### PR TITLE
Simplify zip and merge apis to a single variant each

### DIFF
--- a/examples/circles/main.js
+++ b/examples/circles/main.js
@@ -28,7 +28,7 @@ module.exports = function run() {
 	// Merge the flurry of circles into one stream and start observing it
 	// so that it will actually run (streams are lazy: when not observing
 	// then, they are inert!)
-	most.zipWith(makeDelayedTail, delays, colors)
+	most.zip(makeDelayedTail, delays, colors)
 		.take(nTails)
 		.mergeAll()
 		.forEach(noop);
@@ -43,7 +43,7 @@ module.exports = function run() {
 	// and whose color will be the provided color
 	function makeDelayedTail(delay, color) {
 		var tail = makeTail(circle, color);
-		return mousemoves.delay(delay).zipWith(translate, most.repeat(tail));
+		return mousemoves.delay(delay).zip(translate, most.repeat(tail));
 	}
 
 	// Turn a mouse event into a css translate3d string

--- a/lib/combinators/merge.js
+++ b/lib/combinators/merge.js
@@ -26,7 +26,7 @@ exports.mergeAll = mergeAll;
  * list in time order.  If two events are simultaneous they will be merged in
  * arbitrary order.
  */
-function merge(/*...observables*/) {
+function merge(/*...streams*/) {
 	return mergeArray(copy(arguments));
 }
 

--- a/lib/combinators/zip.js
+++ b/lib/combinators/zip.js
@@ -17,39 +17,19 @@ var Yield = step.Yield;
 var End = step.End;
 
 var tail = base.tail;
-var copy = base.copy;
 var map = base.map;
 var findIndex = base.findIndex;
 
-exports.zipWith = zipWith;
 exports.zip = zip;
 exports.zipArray = zipArray;
-exports.zipArrayWith = zipArrayWith;
 
 /**
  * Combine events from all streams using f
  * @param {function(a:Stream, b:Stream, ...):*} f function to combine items
- * @returns {Stream} observable containing
+ * @returns {Stream} stream containing
  */
-function zipWith(f /*,...streams*/) {
-	return zipArrayWith(f, tail(arguments));
-}
-
-/**
- * Combine events from all streams by collecting them into an array
- * @returns {*}
- */
-function zip(/*...streams*/) {
-	return zipArrayWith(Array, copy(arguments));
-}
-
-/**
- * Combine events from all streams by collecting them into an array
- * @param {Array} streams array of streams to zip
- * @returns {*}
- */
-function zipArray(streams) {
-	return zipArrayWith(Array, streams);
+function zip(f /*,...streams*/) {
+	return zipArray(f, tail(arguments));
 }
 
 /**
@@ -59,7 +39,7 @@ function zipArray(streams) {
  * @returns {Stream} stream containing items from all input streams combined
  * using f
  */
-function zipArrayWith(f, streams) {
+function zipArray(f, streams) {
 	return new Stream(function(ss) {
 		return stepZip(f, ss);
 	}, streams, void 0, disposeAll);

--- a/most.js
+++ b/most.js
@@ -306,7 +306,7 @@ Stream.prototype.concat = function(right) {
 var combine = require('./lib/combinators/combine');
 var combineArray = combine.combineArray;
 
-exports.combine      = combine.combine;
+exports.combine = combine.combine;
 
 /**
  * Combine latest events from all input streams
@@ -323,21 +323,8 @@ Stream.prototype.combine = function(f /*,...streams*/) {
 
 var zip = require('./lib/combinators/zip');
 var zipArray = zip.zipArray;
-var zipArrayWith = zip.zipArrayWith;
 
-exports.zip          = zip.zip;
-exports.zipWith      = zip.zipWith;
-exports.zipArray     = zipArray;
-exports.zipArrayWith = zipArrayWith;
-
-/**
- * Pair-wise combine items with those in s. Given 2 streams:
- * [1,2,3] zip [4,5,6] -> [[1,4],[2,5],[3,6]]
- * @returns {Stream} new stream containing pairs
- */
-Stream.prototype.zip = function(/*,...ss*/) {
-	return zipArray(cons(this, arguments));
-};
+exports.zip = zip.zip;
 
 /**
  * Pair-wise combine items with those in s. Given 2 streams:
@@ -345,8 +332,8 @@ Stream.prototype.zip = function(/*,...ss*/) {
  * @param {function(a:Stream, b:Stream, ...):*} f function to combine items
  * @returns {Stream} new stream containing pairs
  */
-Stream.prototype.zipWith = function(f /*,...ss*/) {
-	return zipArrayWith(f, replace(this, 0, arguments));
+Stream.prototype.zip = function(f /*,...ss*/) {
+	return zipArray(f, replace(this, 0, arguments));
 };
 
 //-----------------------------------------------------------------------
@@ -356,9 +343,8 @@ var merge = require('./lib/combinators/merge');
 var mergeArray = merge.mergeArray;
 var mergeAll = merge.mergeAll;
 
-exports.merge      = merge.merge;
-exports.mergeArray = mergeArray;
-exports.mergeAll   = mergeAll;
+exports.merge    = merge.merge;
+exports.mergeAll = mergeAll;
 
 /**
  * Merge this stream and all the provided streams
@@ -366,7 +352,7 @@ exports.mergeAll   = mergeAll;
  * order.  If two events are simultaneous they will be merged in
  * arbitrary order.
  */
-Stream.prototype.merge = function(/*,...ss*/) {
+Stream.prototype.merge = function(/*,...streams*/) {
 	return mergeArray(cons(this, arguments));
 };
 

--- a/test/zip-test.js
+++ b/test/zip-test.js
@@ -1,57 +1,33 @@
 require('buster').spec.expose();
 var expect = require('buster').expect;
 
-var zip = require('../lib/combinators/zip');
+var zip = require('../lib/combinators/zip').zip;
+var reduce = require('../lib/combinators/reduce').reduce;
 var Stream = require('../lib/Stream');
 
-describe('zipWith', function() {
-	it('should invoke f for each tuple', function() {
-		var spy = this.spy();
-		var a = [1,2,3];
-		var b = [4,5,6];
-		return zip.zipWith(spy, Stream.from(a), Stream.from(b))
-			.reduce(function(i) {
-				expect(spy).toHaveBeenCalledWith(a[i], b[i]);
-				return i + 1;
-			}, 0);
-	});
-});
-
 describe('zip', function() {
-	it('should yield zipped tuples', function() {
-		var a = [1,2,3];
-		var b = [4,5,6];
-		var i = 0;
-		return zip.zip(Stream.from(a), Stream.from(b))
-			.reduce(function(i, zipped) {
-				expect(zipped).toEqual([a[i], b[i]]);
-				return i + 1;
-			}, 0);
-	});
-});
-
-describe('zipArrayWith', function() {
 	it('should invoke f for each tuple', function() {
 		var spy = this.spy();
 		var a = [1,2,3];
 		var b = [4,5,6];
-		return zip.zipArrayWith(spy, [Stream.from(a), Stream.from(b)])
-			.reduce(function(i) {
+		var s = zip(spy, Stream.from(a), Stream.from(b));
+
+		return reduce(function(i) {
 				expect(spy).toHaveBeenCalledWith(a[i], b[i]);
 				return i + 1;
-			}, 0);
+			}, 0, s);
 	});
 
 	it('should end when shortest stream ends', function() {
 		var spy = this.spy();
 		var a = [1,2];
 		var b = [4,5,6];
-		return zip.zipArrayWith(spy, [Stream.from(a), Stream.from(b)])
-			.reduce(function(count) {
+		var s = zip(spy, Stream.from(a), Stream.from(b));
+
+		return reduce(function(count) {
 				return count + 1;
-			}, 0).then(function(count) {
+			}, 0, s).then(function(count) {
 				expect(count).toBe(a.length);
 			});
-
 	});
 });


### PR DESCRIPTION
As per discussion from #36, this aligns the `zip` and `merge` APIs with `combine`.
