### PR TITLE
Add await

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -48,6 +48,8 @@ most.js API
 1. Combining higher order streams
 	* [switch](#switch)
 	* [join](#join)
+1. Awaiting promises
+	* [await](#await)
 1. Delaying streams
 	* [delay](#delay)
 1. Rate limiting streams
@@ -888,6 +890,39 @@ stream.join(): ---a---b--4c-5-d6->
 ```
 
 *TODO: Example*
+
+## Awaiting promises
+
+### await
+
+####`stream.await() -> Stream`
+####`most.await(stream) -> Stream`
+
+Given a stream of promises, ie Stream<Promise<X>>, return a new stream containing the fulfillment values, ie Stream<X>.
+
+```
+promise p:      ---1
+promise q:      ------2
+promise r:      -3
+stream:         -p---q---r->
+stream.await(): ---1--2--3->
+```
+
+Note that event order is preserved, regardless of promise fulfillment order.  The fulfilled event values will arrive at the later of the original event time and the promise fulfillment time.
+
+```js
+var urls = [url1, url2, url3, ...];
+
+function fetchContent(url) {
+   // return a promise
+}
+
+var streamOfPromises = Stream.from(urls).map(fetchContent);
+
+var streamOfContent = streamOfPromises.await();
+
+streamOfContent.forEach(console.log.bind(console));
+```
 
 ## Delaying streams
 

--- a/lib/combinators/await.js
+++ b/lib/combinators/await.js
@@ -1,0 +1,41 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var promise = require('../promises');
+var step = require('../step');
+
+var when = promise.when;
+
+var Yield = step.Yield;
+var End = step.End;
+
+exports.await = await;
+
+/**
+ * Await promises, turning a Stream<Promise<X>> into Stream<X>.  Preserves
+ * event order, but timeshifts events based on promise resolution time.
+ * @param {Stream<Promise<X>>} stream stream whose values are promises
+ * @returns {Stream<X>} stream containing non-promise values
+ */
+function await(stream) {
+	var stepper = stream.step;
+	var scheduler = stream.scheduler;
+
+	return stream.beget(function(s) {
+		return stepAwait(scheduler, stepper, s);
+	}, stream.state);
+}
+
+function stepAwait (scheduler, stepper, s) {
+	return when(function (i) {
+		return i.done ? new End(scheduler.now(), i.value, i.state)
+			 : awaitValue(scheduler, i.value, i.state);
+	}, when(stepper, s));
+}
+
+function awaitValue (scheduler, promise, state) {
+	return promise.then(function(x) {
+		return new Yield(scheduler.now(), x, state);
+	});
+}

--- a/most.js
+++ b/most.js
@@ -375,6 +375,22 @@ Stream.prototype.merge = function(/*,...streams*/) {
 };
 
 //-----------------------------------------------------------------------
+// Awaiting Promises
+
+var await = require('./lib/combinators/await').await;
+
+exports.await = await;
+
+/**
+ * Await promises, turning a Stream<Promise<X>> into Stream<X>.  Preserves
+ * event order, but timeshifts events based on promise resolution time.
+ * @returns {Stream<X>} stream containing non-promise values
+ */
+Stream.prototype.await = function() {
+	return await(this);
+};
+
+//-----------------------------------------------------------------------
 // Higher-order stream
 //-----------------------------------------------------------------------
 

--- a/test/await-test.js
+++ b/test/await-test.js
@@ -1,0 +1,25 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var await = require('../lib/combinators/await').await;
+var observe = require('../lib/combinators/observe').observe;
+var Stream = require('../lib/Stream');
+var resolve = require('../lib/promises').Promise.resolve;
+
+var sentinel = { value: 'sentinel' };
+
+function identity(x) {
+	return x;
+}
+
+describe('await', function() {
+
+	it('should await promises', function() {
+		var s = await(Stream.of(resolve(sentinel)));
+
+		return observe(function(x) {
+			expect(x).toBe(sentinel);
+		}, s);
+	});
+
+});


### PR DESCRIPTION
This adds `most.await(stream)` and `stream.await()` to turn `Stream<Promise<X>>` into `Stream<X>`.  The goal is to make it easier to work with promise-returning functions.

Close #54 
