### PR TITLE
Add loop

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -45,6 +45,8 @@ most.js API
 	* [until](#until), alias [takeUntil](#until)
 	* [since](#since), alias [skipUntil](#since)
 	* [during](#during)
+1. Looping
+	* [loop](#loop)
 1. Consuming streams
 	* [reduce](#reduce)
 	* [observe](#observe), alias [forEach](#observe)
@@ -878,6 +880,39 @@ var timeWindow = start.constant(end);
 
 most.fromEvent('mousemove', document)
 	.during(timeWindow)
+	.observe(console.log.bind(console));
+```
+
+## Looping
+
+### loop
+
+####`stream.loop(stepper, seed) -> Stream`
+####`most.loop(stepper, seed, stream) -> Stream`
+
+Create a feedback loop that emits one value and feeds back another to be used in the next iteration.
+
+It allows you to maintain and update a "state" (aka feedback, aka `seed` for the next iteration) while emitting a different value.  In contrast, [`scan`](#scan) feeds back and emits the same value.
+
+```js
+// Average an array of values
+function average(values) {
+	return values.reduce(function(sum, x) {
+		return sum + x;
+	}, 0) / values.length;
+}
+
+// Emit the simple (ie windowed) moving average of the 10 most recent values
+stream.loop(function(values, x) {
+	values.push(x);
+	values = values.slice(-10); // Keep up to 10 most recent
+	var avg = average(values);
+
+	// Return { seed, value } pair.
+	// seed will feed back into next iteration
+	// value will be propagated
+	return { seed: values, value: avg };
+}, [])
 	.observe(console.log.bind(console));
 ```
 

--- a/lib/combinator/loop.js
+++ b/lib/combinator/loop.js
@@ -1,0 +1,51 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Stream = require('../Stream');
+var Pipe = require('../sink/Pipe');
+
+exports.loop = loop;
+
+/**
+ * Generalized feedback loop. Call a stepper function for each event. The stepper
+ * will be called with 2 params: the current seed and the an event value.  It must
+ * return a new { seed, value } pair. The `seed` will be fed back into the next
+ * invocation of stepper, and the `value` will be propagated as the event value.
+ * @param {function(seed:*, value:*):{seed:*, value:*}} stepper loop step function
+ * @param {*} seed initial seed value passed to first stepper call
+ * @param {Stream} stream event stream
+ * @returns {Stream} new stream whose values are the `value` field of the objects
+ * returned by the stepper
+ */
+function loop(stepper, seed, stream) {
+	return new Stream(new Loop(stepper, seed, stream.source));
+}
+
+function Loop(stepper, seed, source) {
+	this.step = stepper;
+	this.seed = seed;
+	this.source = source;
+}
+
+Loop.prototype.run = function(sink, scheduler) {
+	return this.source.run(new LoopSink(this.step, this.seed, sink), scheduler);
+};
+
+function LoopSink(stepper, seed, sink) {
+	this.step = stepper;
+	this.seed = seed;
+	this.sink = sink;
+}
+
+LoopSink.prototype.error = Pipe.prototype.error;
+
+LoopSink.prototype.event = function(t, x) {
+	var result = this.step(this.seed, x);
+	this.seed = result.seed;
+	this.sink.event(t, result.value);
+};
+
+LoopSink.prototype.end = function(t) {
+	this.sink.end(t, this.seed);
+};

--- a/most.js
+++ b/most.js
@@ -97,6 +97,26 @@ Stream.prototype.drain = function() {
 
 //-------------------------------------------------------
 
+var loop = require('./lib/combinator/loop').loop;
+
+exports.loop = loop;
+
+/**
+ * Generalized feedback loop. Call a stepper function for each event. The stepper
+ * will be called with 2 params: the current seed and the an event value.  It must
+ * return a new { seed, value } pair. The `seed` will be fed back into the next
+ * invocation of stepper, and the `value` will be propagated as the event value.
+ * @param {function(seed:*, value:*):{seed:*, value:*}} stepper loop step function
+ * @param {*} seed initial seed value passed to first stepper call
+ * @returns {Stream} new stream whose values are the `value` field of the objects
+ * returned by the stepper
+ */
+Stream.prototype.loop = function(stepper, seed) {
+	return loop(stepper, seed, this);
+};
+
+//-------------------------------------------------------
+
 var accumulate = require('./lib/combinator/accumulate');
 
 exports.scan   = accumulate.scan;

--- a/test/combinator/loop-test.js
+++ b/test/combinator/loop-test.js
@@ -1,0 +1,55 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var Stream = require('../../lib/Stream');
+var loop = require('../../lib/combinator/loop').loop;
+var reduce = require('../../lib/combinator/accumulate').reduce;
+var drain = require('../../lib/combinator/observe').drain;
+var fromArray = require('../../lib/source/fromArray').fromArray;
+var throwError = require('../../lib/combinator/errors').throwError;
+var core = require('../../lib/source/core');
+var streamOf = core.of;
+
+var FakeDisposeSource = require('../helper/FakeDisposeSource');
+
+var sentinel = { value: 'sentinel' };
+var other = { value: 'other' };
+
+function toPair(z, x) {
+	return { value: x, seed: z };
+}
+
+describe('loop', function() {
+	it('should call stepper with seed, value', function() {
+		var a = ['a', 'b', 'c', 'd'];
+
+		var s = loop(function(z, x) {
+			return { value: x+z, seed: z+1 };
+		}, 0, fromArray(a));
+
+		return reduce(function(r, x) {
+			return r.concat(x);
+		}, [], s).then(function(result) {
+			expect(result).toEqual(['a0', 'b1', 'c2', 'd3']);
+		});
+	});
+
+	it('should propagate errors', function () {
+		var s = loop(toPair, other, throwError(sentinel));
+
+		return drain(s).catch(function (e) {
+			expect(e).toBe(sentinel);
+		});
+	});
+
+	it('should dispose', function() {
+		var dispose = this.spy();
+
+		var stream = new Stream(new FakeDisposeSource(dispose, streamOf(sentinel).source));
+		var s = loop(toPair, 0, stream);
+
+		return drain(s).then(function() {
+			expect(dispose).toHaveBeenCalledOnce();
+		});
+	});
+});


### PR DESCRIPTION
Add generalized loop combinator.  This is more general than scan: scan can be implemented using loop, but not vice versa (it would require an extra map step afterward to extract the value)

This is def open to discussion: Have you encountered use cases for it?  I have on several occasions, but I always forget to write them down for times like this :)

Still needs:

- [x] `most.loop` and `Stream.prototype.loop`
- [x] Unit tests
- [x] API docs