### PR TITLE
Add value to most.periodic()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -176,6 +176,8 @@ stream.take(100)
 
 ### most.repeat
 
+**DEPRECATED:** Use [`most.periodic(period, x)`](#mostperiodic) to create a stream of periodic `x`s, or [`most.iterate(f, x)`](#mostiterate) or [`most.unfold(f, seed)`](#mostunfold) to repeat a value with finer grained control over event times.
+
 ####`most.repeat(x) -> Stream`
 
 Create a stream containing infinite occurrences of `x`.
@@ -186,14 +188,14 @@ most.repeat(x): xxxxxxx->
 
 ### most.periodic
 
-####`most.periodic(period) -> Stream`
+####`most.periodic(period, x) -> Stream`
 
 ```
-most.periodic(2): a-b-c-d-e-f->
-most.periodic(5): a----b----c->
+most.periodic(2, x): x-x-x-x-x-x->
+most.periodic(5, x): x----x----x->
 ```
 
-Create an infinite stream containing events that arrive every `period` milliseconds. The value of each event is its arrival time in milliseconds.
+Create an infinite stream containing events that arrive every `period` milliseconds, and whose value is `x`.
 
 ### most.empty
 

--- a/lib/source/iterate.js
+++ b/lib/source/iterate.js
@@ -21,6 +21,7 @@ function iterate(f, x) {
 }
 
 /**
+ * @deprecate Use most.periodic(period, x), most.iterate(f, x), or most.unfold(f, seed)
  * Create an infinite stream of xs
  * @param {*} x
  * @returns {Stream} infinite stream where all items are x

--- a/lib/source/periodic.js
+++ b/lib/source/periodic.js
@@ -11,19 +11,21 @@ exports.periodic = periodic;
 
 /**
  * Create a stream that emits the current time periodically
- * @param {Number} period
+ * @param {Number} period periodicity of events in millis
+ * @param {*) value value to emit each period
  * @returns {Stream} new stream that emits the current time every period
  */
-function periodic(period) {
-	return new Stream(new MulticastSource(new Periodic(period)));
+function periodic(period, value) {
+	return new Stream(new MulticastSource(new Periodic(period, value)));
 }
 
-function Periodic(period) {
+function Periodic(period, value) {
 	this.period = period;
+	this.value = value;
 }
 
 Periodic.prototype.run = function(sink, scheduler) {
-	var task = scheduler.periodic(this.period, new PropagateTask(emit, void 0, sink));
+	var task = scheduler.periodic(this.period, new PropagateTask(emit, this.value, sink));
 	return new Disposable(cancelTask, task);
 };
 
@@ -32,5 +34,5 @@ function cancelTask(task) {
 }
 
 function emit(t, x, sink) {
-	sink.event(t, t);
+	sink.event(t, x);
 }

--- a/test/combinator/timestamp-test.js
+++ b/test/combinator/timestamp-test.js
@@ -14,7 +14,7 @@ describe('timestamp', function() {
 		var s = take(10, timestamp(periodic(1)));
 
 		return observe(function(timeValue) {
-			expect(timeValue.value).toBe(timeValue.time);
+			expect(typeof timeValue.time).toBe('number');
 		}, s);
 	});
 });

--- a/test/source/periodic-test.js
+++ b/test/source/periodic-test.js
@@ -3,23 +3,28 @@ var expect = require('buster').expect;
 
 var periodic = require('../../lib/source/periodic').periodic;
 var take = require('../../lib/combinator/slice').take;
+var timestamp = require('../../lib/combinator/timestamp').timestamp;
 var reduce = require('../../lib/combinator/accumulate').reduce;
 var scheduler = require('../../lib/scheduler/defaultScheduler');
 
+var sentinel = { value: 'sentinel' };
+
 describe('periodic', function() {
-	it('should emit events at tick periods', function() {
+	it('should emit value at tick periods', function() {
 		var n = 10;
-		var s = take(n, periodic(1));
+		var s = take(n, timestamp(periodic(1, sentinel)));
 
 		return reduce(function(t0, t1) {
 			n -= 1;
 
-			if(t0 >= 0) {
-				expect(t1 - t0).toBe(1);
+			if(t0.time >= 0) {
+				expect(t1.time - t0.time).toBe(1);
 			}
 
+			expect(t1.value).toBe(sentinel);
+
 			return t1;
-		}, -1, s).then(function(t) {
+		}, { time: -1, value: sentinel }, s).then(function(t) {
 			expect(scheduler.now()).not.toBeLessThan(t);
 			expect(n).toBe(0);
 		});


### PR DESCRIPTION
This deprecates `most.repeat` in favor of adding a value to `most.periodic`, eg `most.periodic(period, x)`.

Close #74