### PR TITLE
Add most.generate to compute a stream from an async generator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -14,6 +14,7 @@ most.js API
 	* [most.never](#mostnever)
 	* [most.iterate](#mostiterate)
 	* [most.unfold](#mostunfold)
+	* [most.generate](#mostgenerate)
 	* [most.fromEvent](#mostfromevent)
 	* [most.fromEventWhere](#mostfromeventwhere)
 	* [most.create](#mostcreate)
@@ -274,6 +275,33 @@ most.unfold(function(id) {
 		return { value: content, seed: id + 1 };
 	});
 }, 1);
+```
+
+### most.generate
+
+####`most.generate(generator, ...args) -> Stream`
+
+Build a stream by running an *asynchronous generator*: a generator which yields promises.
+
+When the generator yields a promise, the promise's fulfillment value will be added to the stream.  If the promise rejects, an exception will be thrown in the generator.  You can use `try/catch` to handle the exception.
+
+```js
+function delayPromise(ms, value) {
+	return new Promise(resolve => setTimeout(() => resolve(value), delay));
+}
+
+function* countdownGet(delay, start) {
+	for(let i = start; i > 0; --i) {
+		yield delayPromise(delay, i);
+	}
+}
+
+// Logs
+// 3 (after 1 second)
+// 2 (after 1 more second)
+// 1 (after 1 more second)
+most.generate(countdown, 1000, 3)
+	.observe(x => console.log(x))
 ```
 
 ### most.fromEvent

--- a/lib/source/generate.js
+++ b/lib/source/generate.js
@@ -1,0 +1,71 @@
+/** @license MIT License (c) copyright 2010-2014 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Stream = require('../Stream');
+var Promise = require('../Promise');
+var base = require('../base');
+
+exports.generate = generate;
+
+/**
+ * Compute a stream using an *async* generator, which yields promises
+ * to control event times.
+ * @param f
+ * @returns {Stream}
+ */
+function generate(f /*, ...args */) {
+	return new Stream(new GenerateSource(f, base.tail(arguments)));
+}
+
+function GenerateSource(f, args) {
+	this.f = f;
+	this.args = args;
+}
+
+GenerateSource.prototype.run = function(sink, scheduler) {
+	return new Generate(this.f.apply(void 0, this.args), sink, scheduler);
+};
+
+function Generate(iterator, sink, scheduler) {
+	this.iterator = iterator;
+	this.sink = sink;
+	this.scheduler = scheduler;
+	this.active = true;
+
+	var self = this;
+	function err(e) {
+		self.sink.error(self.scheduler.now(), e);
+	}
+
+	Promise.resolve(this).then(next).catch(err);
+}
+
+function next(generate, x) {
+	return generate.active ? handle(generate, generate.iterator.next(x)) : x;
+}
+
+function handle(generate, result) {
+	if (result.done) {
+		return generate.sink.end(generate.scheduler.now(), result.value);
+	}
+
+	return Promise.resolve(result.value).then(function (x) {
+		return emit(generate, x);
+	}, function(e) {
+		return error(generate, e);
+	});
+}
+
+function emit(generate, x) {
+	generate.sink.event(generate.scheduler.now(), x);
+	return next(generate, x);
+}
+
+function error(generate, e) {
+	return handle(generate, generate.iterator.throw(e));
+}
+
+Generate.prototype.dispose = function() {
+	this.active = false;
+};

--- a/lib/source/iterate.js
+++ b/lib/source/iterate.js
@@ -10,7 +10,7 @@ exports.iterate = iterate;
 exports.repeat = repeat;
 
 /**
- * Produce a stream by iteratively calling f to produce values
+ * Compute a stream by iteratively calling f to produce values
  * Event times may be controlled by returning a Promise from f
  * @param {function(x:*):*|Promise<*>} f
  * @param {*} x initial value

--- a/lib/source/unfold.js
+++ b/lib/source/unfold.js
@@ -8,7 +8,7 @@ var Promise = require('../Promise');
 exports.unfold = unfold;
 
 /**
- * Produce a stream by unfolding tuples of future values from a seed value
+ * Compute a stream by unfolding tuples of future values from a seed value
  * Event times may be controlled by returning a Promise from f
  * @param {function(seed:*):{value:*, seed:*, done:boolean}|Promise<{value:*, seed:*, done:boolean}>} f unfolding function accepts
  *  a seed and returns a new tuple with a value, new seed, and boolean done flag.

--- a/most.js
+++ b/most.js
@@ -150,10 +150,12 @@ Stream.prototype.reduce = function(f, initial) {
 
 var unfold = require('./lib/source/unfold');
 var iterate = require('./lib/source/iterate');
+var generate = require('./lib/source/generate');
 var build = require('./lib/combinator/build');
 
 exports.unfold    = unfold.unfold;
 exports.iterate   = iterate.iterate;
+exports.generate  = generate.generate;
 exports.repeat    = iterate.repeat;
 exports.concat    = build.cycle;
 exports.concat    = build.concat;

--- a/test/helper/ArrayIterable.js
+++ b/test/helper/ArrayIterable.js
@@ -1,13 +1,7 @@
 var makeIterable = require('../../lib/iterable').makeIterable;
+var Iteration = require('./Iteration');
 
 module.exports = ArrayIterable;
-
-function Iteration(done, value) {
-	this.done = done;
-	this.value = value;
-}
-
-var DONE = Iteration.DONE = new Iteration(true, void 0);
 
 function ArrayIterable(a) {
 	this.array = a;
@@ -31,5 +25,5 @@ ArrayIterator.prototype.next = function() {
 		return new Iteration(false, x);
 	}
 
-	return DONE;
+	return Iteration.DONE;
 };

--- a/test/helper/Iteration.js
+++ b/test/helper/Iteration.js
@@ -1,0 +1,8 @@
+module.exports = Iteration;
+
+function Iteration(done, value) {
+	this.done = done;
+	this.value = value;
+}
+
+Iteration.DONE = new Iteration(true, void 0);

--- a/test/helper/delayPromise.js
+++ b/test/helper/delayPromise.js
@@ -1,0 +1,11 @@
+var Promise = require('../../lib/Promise');
+
+module.exports = delayPromise;
+
+function delayPromise(ms, x) {
+	return new Promise(function(resolve) {
+		setTimeout(function() {
+			resolve(x);
+		}, ms);
+	});
+}

--- a/test/source/generate-test.js
+++ b/test/source/generate-test.js
@@ -1,0 +1,32 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var generate = require('../../lib/source/generate').generate;
+var reduce = require('../../lib/combinator/accumulate').reduce;
+var iterable = require('../../lib/iterable');
+var ArrayIterable = require('../helper/ArrayIterable');
+var delayPromise = require('../helper/delayPromise');
+
+var sentinel = { value: 'sentinel' };
+var other = { value: 'other' };
+
+function makeAsyncIterator(ms, n) {
+	var a = new Array(n);
+	for(var i=0; i<n; ++i) {
+		a[i] = delayPromise(ms, i);
+	}
+
+	return iterable.getIterator(new ArrayIterable(a));
+}
+
+describe('generate', function() {
+	it('should contain iterable items', function() {
+		return reduce(function(a, x) {
+			a.push(x);
+			return a;
+		}, [], generate(makeAsyncIterator, 10, 5)).then(function(a) {
+			expect(a).toEqual([0,1,2,3,4]);
+		});
+	});
+
+});


### PR DESCRIPTION
This computes a (potentially infinite) stream, similarly to `most.unfold` or `most.iterate`, from an *async* generator--that is, a generator that yields promises.  This allows the generator to control event times.

For example, compute an infinite stream of random values at random intervals:

```js
function* randoms() {
	for(;;) yield new Promise(resolve => setTimeout(() => resolve(Math.random()), 1000 * Math.random()));
}

var stream = most.generate(randoms);
```

Still needs:

- [x] Unit tests
- [x] API docs