### PR TITLE
Make applicative more sensible

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -635,15 +635,15 @@ most.from([1, 2])
 ####`streamOfFunctions.ap(stream) -> Stream`
 ####`most.ap(streamOfFunctions, stream) -> Stream`
 
-Apply all the functions in `streamOfFunctions` to all the values in `stream`.
+Apply the latest function in `streamOfFunctions` to the latest value in `stream`.
 
 ```
-streamOfFunctions:            f-g-h|
-stream:                       x-y-z|
-streamOfFunctions.ap(stream): f(x)-f(y)-f(z)-g(x)-g(y)-g(z)-h(x)-h(y)-h(z)|
+streamOfFunctions:            --f---------g--------h------>
+stream:                       -a-------b-------c-------d-->
+streamOfFunctions.ap(stream): --fa-----fb-gb---gc--hc--hd->
 ```
 
-This effectively creates the cross-product of `streamOfFunctions` and `stream`.  As shown in the diagram above, `stream` will be traversed multiple times--once for each event in `streamOfFunctions`.
+In effect, `ap` applies a *time-varying function* to a *time-varying value*.
 
 ### timestamp
 

--- a/lib/combinator/combine.js
+++ b/lib/combinator/combine.js
@@ -72,6 +72,7 @@ function CombineSink(f, sinks, sink) {
 	this.sinks = sinks;
 	this.sink = sink;
 	this.ready = false;
+	this.activeCount = sinks.length;
 }
 
 CombineSink.prototype.event = function(t /*, indexSink */) {
@@ -85,8 +86,10 @@ CombineSink.prototype.event = function(t /*, indexSink */) {
 	}
 };
 
-CombineSink.prototype.end = function(t, indexSink) {
-	this.sink.end(t, indexSink.value);
+CombineSink.prototype.end = function(t, indexedValue) {
+	if(--this.activeCount === 0) {
+		this.sink.end(t, indexedValue.value);
+	}
 };
 
 CombineSink.prototype.error = Pipe.prototype.error;

--- a/lib/combinator/transform.js
+++ b/lib/combinator/transform.js
@@ -3,8 +3,8 @@
 /** @author John Hann */
 
 var Stream = require('../Stream');
-var flatMap = require('./flatMap').flatMap;
 var Pipe = require('../sink/Pipe');
+var combine = require('./combine').combine;
 
 exports.map = map;
 exports.ap  = ap;
@@ -22,16 +22,21 @@ function map(f, stream) {
 }
 
 /**
- * Assume fs is a stream containing functions, and apply each function to each value
- * in the xs stream.  This generates, in effect, a cross product.
- * @param {Stream} fs stream of functions to apply to the xs
- * @param {Stream} xs stream of values to which to apply all the fs
- * @returns {Stream} stream containing the cross product of items
+ * Assume fs is a stream containing functions, and apply the latest function
+ * in fs to the latest value in xs.
+ * fs:         --f---------g--------h------>
+ * xs:         -a-------b-------c-------d-->
+ * ap(fs, xs): --fa-----fb-gb---gc--hc--hd->
+ * @param {Stream} fs stream of functions to apply to the latest x
+ * @param {Stream} xs stream of values to which to apply all the latest f
+ * @returns {Stream} stream containing all the applications of fs to xs
  */
 function ap(fs, xs) {
-	return flatMap(function(f) {
-		return map(f, xs);
-	}, fs);
+	return combine(apply, fs, xs);
+}
+
+function apply(f, x) {
+	return f(x);
 }
 
 /**

--- a/lib/sink/IndexSink.js
+++ b/lib/sink/IndexSink.js
@@ -38,9 +38,8 @@ IndexSink.prototype.end = function(t, x) {
 	if(!this.active) {
 		return;
 	}
-	this.value = x;
 	this.active = false;
-	this.sink.end(t, this);
+	this.sink.end(t, { index: this.index, value: x });
 };
 
 IndexSink.prototype.error = Sink.prototype.error;

--- a/test/combine-test.js
+++ b/test/combine-test.js
@@ -15,7 +15,7 @@ var sentinel = { value: 'sentinel' };
 
 describe('combine', function() {
 	it('should yield initial only after all inputs yield', function() {
-		var s1 = periodic(1);
+		var s1 = streamOf(1);
 		var s2 = streamOf(sentinel);
 
 		var sc = combine(Array, s1, delay(2, s2));
@@ -49,7 +49,8 @@ describe('combine', function() {
 					[2,1],
 					[2,3],
 					[4,3],
-					[4,5]
+					[4,5],
+					[6,5]
 				]);
 			});
 	});

--- a/test/lift-test.js
+++ b/test/lift-test.js
@@ -2,7 +2,8 @@ require('buster').spec.expose();
 var expect = require('buster').expect;
 
 var lift = require('../lib/combinator/lift').lift;
-var repeat = require('../lib/source/iterate').repeat;
+var periodic = require('../lib/source/periodic').periodic;
+var take = require('../lib/combinator/slice').take;
 var observe = require('../lib/combinator/observe').observe;
 var streamOf = require('../lib/source/core').of;
 
@@ -26,13 +27,13 @@ describe('lift', function() {
 
 		var lifted = lift(f);
 
-		var a = repeat('a');
-		var b = repeat('b');
+		var a = periodic(1, 'a');
+		var b = periodic(5, 'b');
 		var c = streamOf('c');
 
 		return observe(function(x) {
 			expect(x).toBe(f('a', 'b', 'c'));
-		}, lifted(a, b, c));
+		}, take(3, lifted(a, b, c)));
 
 	});
 });


### PR DESCRIPTION
This is a much more sensible behavior for applicative.  The previous cross product (which is standard for a finite, synchronous list) had the very serious issue of observing the `xs` stream many times.  The new approach applies the latest `f` to the latest `x`, when either a new `f` or new `x` arrives.  Or, put another way, it applies a *time-varying function* to a *time-varying value*, which is a fairly intuitive definition, imho.

The standard ap laws still pass, which further reinforces that this is a valid approach.

Note that this changes the behavior of combine such that it only ends once all input streams end.  That's potentially a breaking change, so will go out in 0.12.0.

Close #73