### PR TITLE
Deprecate fromEventWhere

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -325,13 +325,44 @@ var clicks = most.fromEvent('click', document.querySelector('.the-button'));
 // We can do some event delegation by applying a filter to the stream
 // in conjunction with e.target.matches this will allow only events with 
 // .the-button class to be processed
-var clicks = most.fromEvent('click', document.querySelector('.container'));
-clicks.filter(function(e){
-    return e.target.matches('.the-button');
-}).forEach(doSomething);
+var container = document.querySelector('.container');
+most.fromEvent('click', container);
+	.filter(function(e){
+    	return e.target.matches('.the-button');
+	})
+	.forEach(doSomething);
+```
+
+```js
+// Using preventDefault
+var form = document.querySelector('form');
+most.fromEvent('submit', form)
+	.tap(function(e) {
+		e.preventDefault();
+	})
+	.map(parseForm)
+	.map(JSON.stringify)
+	.forEach(postToServer);
+```
+
+```js
+// Using event delegation with Element.matches
+// This allows only events with the .toggle-button class
+// It also only calls preventDefault on allowed events
+var container = document.querySelector('.container');
+most.fromEvent('click', container)
+	.filter(function(e) {
+		return e.target.matches('.toggle-button');
+	})
+	.tap(function(e) {
+		e.preventDefault();
+	})
+    .forEach(doSomething);
 ```
 
 ### most.fromEventWhere
+
+**DEPRECATED:** Use [`most.fromEvent`](#mostfromevent) in conjunction with [`filter`](#filter) to handle selector matching, and [`tap`](#tap) to handle `preventDefault` and/or `stopPropagation` for DOM events.
 
 ####`most.fromEventWhere(predicate, eventType, source) -> Stream`
 

--- a/lib/source/fromEvent.js
+++ b/lib/source/fromEvent.js
@@ -9,10 +9,20 @@ var base = require('../base');
 exports.fromEvent = fromEvent;
 exports.fromEventWhere = fromEventWhere;
 
+/**
+ * Create a stream from an EventTarget, such as a DOM Node, or EventEmitter.
+ * @param {String} event event type name, e.g. 'click'
+ * @param {EventTarget|EventEmitter} source EventTarget or EventEmitter
+ * @returns {Stream} stream containing all events of the specified type
+ * from the source.
+ */
 function fromEvent(event, source) {
 	return fromEventWhere(always, event, source);
 }
 
+/**
+ * @deprecated Use fromEvent(...).filter or fromEvent(...).tap instead
+ */
 function fromEventWhere(predicate, event, source) {
 	return new Stream(new MulticastSource(new EventSource(predicate, event, source)));
 }

--- a/test/source/fromEvent-test.js
+++ b/test/source/fromEvent-test.js
@@ -28,7 +28,6 @@ describe('fromEventWhere', function() {
 		it('should unlisten on end', function() {
 			return verifyUnlistenOnEndWhere.call(this, isSentinel, new FakeEventTarget());
 		});
-
 	});
 
 	describe('given an EventEmitter', function() {
@@ -77,6 +76,21 @@ describe('fromEvent', function() {
 			return verifyUnlistenOnEnd.call(this, new FakeEventTarget());
 		});
 
+		it('should propagate event synchronously', function() {
+			var tick = 0;
+			var source = new FakeEventTarget();
+			var s = fromEvent('test', source);
+
+			setTimeout(function() {
+				tick = 1;
+				source.emit(sentinel);
+				tick = 2;
+			}, 0);
+
+			return observe(function() {
+				expect(tick).toBe(1);
+			}, take(1, s));
+		});
 	});
 
 	describe('given an EventEmitter', function() {


### PR DESCRIPTION
I haven't thought of a reason *not* to deprecate it.  We could release this deprecation in 0.13 and remove for either 0.14, or 1.0.  If we think of a reason to keep it between now and then, we can reinstate it.

Still needs:

- [x] Update docs

See #86