### PR TITLE
Implement filter + map fusion

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,7 @@
 {
 	"browser": true,
 	"node": true,
-	"predef": [ "-Promise" ],
+	"predef": [ "-Promise", "-Map" ],
 	"boss": true,
 	"curly": true,
 	"eqnull": true,

--- a/lib/base.js
+++ b/lib/base.js
@@ -4,6 +4,8 @@
 
 exports.noop = noop;
 exports.identity = identity;
+exports.compose = compose;
+
 exports.cons = cons;
 exports.append = append;
 exports.drop = drop;
@@ -20,6 +22,12 @@ function noop() {}
 
 function identity(x) {
 	return x;
+}
+
+function compose(f, g) {
+	return function(x) {
+		return f(g(x));
+	};
 }
 
 function cons(x, array) {

--- a/lib/combinator/filter.js
+++ b/lib/combinator/filter.js
@@ -4,6 +4,7 @@
 
 var Stream = require('../Stream');
 var Sink = require('../sink/Pipe');
+var Filter = require('../fusion/Filter');
 
 exports.filter = filter;
 exports.distinct = distinct;
@@ -16,7 +17,7 @@ exports.distinctBy = distinctBy;
  * @returns {Stream} stream containing only items for which predicate returns truthy
  */
 function filter(p, stream) {
-	return new Stream(new Filter(p, stream.source));
+	return new Stream(Filter.create(p, stream.source));
 }
 
 /**
@@ -37,28 +38,6 @@ function distinct(stream) {
 function distinctBy(equals, stream) {
 	return new Stream(new Distinct(equals, stream.source));
 }
-
-function Filter(p, source) {
-	this.p = p;
-	this.source = source;
-}
-
-Filter.prototype.run = function(sink, scheduler) {
-	return this.source.run(new FilterSink(this.p, sink), scheduler);
-};
-
-function FilterSink(p, sink) {
-	this.p = p;
-	this.sink = sink;
-}
-
-FilterSink.prototype.end   = Sink.prototype.end;
-FilterSink.prototype.error = Sink.prototype.error;
-
-FilterSink.prototype.event = function(t, x) {
-	var p = this.p;
-	p(x) && this.sink.event(t, x);
-};
 
 function Distinct(equals, source) {
 	this.equals = equals;

--- a/lib/combinator/transform.js
+++ b/lib/combinator/transform.js
@@ -3,8 +3,8 @@
 /** @author John Hann */
 
 var Stream = require('../Stream');
-var Pipe = require('../sink/Pipe');
 var combine = require('./combine').combine;
+var Map = require('../fusion/Map');
 
 exports.map = map;
 exports.ap  = ap;
@@ -18,7 +18,7 @@ exports.tap = tap;
  * @returns {Stream} stream containing items transformed by f
  */
 function map(f, stream) {
-	return new Stream(new Map(f, stream.source));
+	return new Stream(Map.create(f, stream.source));
 }
 
 /**
@@ -64,25 +64,3 @@ function tap(f, stream) {
 		return x;
 	}, stream);
 }
-
-function Map(f, source) {
-	this.f = f;
-	this.source = source;
-}
-
-Map.prototype.run = function(sink, scheduler) {
-	return this.source.run(new MapSink(this.f, sink), scheduler);
-};
-
-function MapSink(f, sink) {
-	this.f = f;
-	this.sink = sink;
-}
-
-MapSink.prototype.end   = Pipe.prototype.end;
-MapSink.prototype.error = Pipe.prototype.error;
-
-MapSink.prototype.event = function(t, x) {
-	var f = this.f;
-	this.sink.event(t, f(x));
-};

--- a/lib/fusion/Filter.js
+++ b/lib/fusion/Filter.js
@@ -1,0 +1,44 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Pipe = require('../sink/Pipe');
+var predicate = require('../predicate');
+
+module.exports = Filter;
+
+function Filter(p, source) {
+	this.p = p;
+	this.source = source;
+}
+
+/**
+ * Create a filtered source, fusing adjacent filter.filter if possible
+ * @param {function(x:*):boolean} p filtering predicate
+ * @param {{run:function}} source source to filter
+ * @returns {Filter} filtered source
+ */
+Filter.create = function createFilter(p, source) {
+	if (source instanceof Filter) {
+		return new Filter(predicate.and(source.p, p), source.source);
+	}
+
+	return new Filter(p, source);
+};
+
+Filter.prototype.run = function(sink, scheduler) {
+	return this.source.run(new FilterSink(this.p, sink), scheduler);
+};
+
+function FilterSink(p, sink) {
+	this.p = p;
+	this.sink = sink;
+}
+
+FilterSink.prototype.end   = Pipe.prototype.end;
+FilterSink.prototype.error = Pipe.prototype.error;
+
+FilterSink.prototype.event = function(t, x) {
+	var p = this.p;
+	p(x) && this.sink.event(t, x);
+};

--- a/lib/fusion/FilterMap.js
+++ b/lib/fusion/FilterMap.js
@@ -1,0 +1,32 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Pipe = require('../sink/Pipe');
+
+module.exports = FilterMap;
+
+function FilterMap(p, f, source) {
+	this.p = p;
+	this.f = f;
+	this.source = source;
+}
+
+FilterMap.prototype.run = function(sink, scheduler) {
+	return this.source.run(new FilterMapSink(this.p, this.f, sink), scheduler);
+};
+
+function FilterMapSink(p, f, sink) {
+	this.p = p;
+	this.f = f;
+	this.sink = sink;
+}
+
+FilterMapSink.prototype.event = function(t, x) {
+	var f = this.f;
+	var p = this.p;
+	p(x) && this.sink.event(t, f(x));
+};
+
+FilterMapSink.prototype.end = Pipe.prototype.end;
+FilterMapSink.prototype.error = Pipe.prototype.error;

--- a/lib/fusion/Map.js
+++ b/lib/fusion/Map.js
@@ -1,0 +1,55 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Pipe = require('../sink/Pipe');
+var Filter = require('./Filter');
+var FilterMap = require('./FilterMap');
+var base = require('../base');
+
+module.exports = Map;
+
+function Map(f, source) {
+	this.f = f;
+	this.source = source;
+}
+
+/**
+ * Create a mapped source, fusing adjacent map.map, filter.map,
+ * and filter.map.map if possible
+ * @param {function(*):*} f mapping function
+ * @param {{run:function}} source source to map
+ * @returns {Map|FilterMap} mapped source, possibly fused
+ */
+Map.create = function createMap(f, source) {
+	if(source instanceof Map) {
+		return new Map(base.compose(f, source.f), source.source);
+	}
+
+	if(source instanceof Filter) {
+		return new FilterMap(source.p, f, source.source);
+	}
+
+	if(source instanceof FilterMap) {
+		return new FilterMap(source.p, base.compose(f, source.f), source.source);
+	}
+
+	return new Map(f, source);
+};
+
+Map.prototype.run = function(sink, scheduler) {
+	return this.source.run(new MapSink(this.f, sink), scheduler);
+};
+
+function MapSink(f, sink) {
+	this.f = f;
+	this.sink = sink;
+}
+
+MapSink.prototype.end   = Pipe.prototype.end;
+MapSink.prototype.error = Pipe.prototype.error;
+
+MapSink.prototype.event = function(t, x) {
+	var f = this.f;
+	this.sink.event(t, f(x));
+};

--- a/lib/predicate.js
+++ b/lib/predicate.js
@@ -1,0 +1,9 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+exports.and = function and(p, q) {
+	return function(x) {
+		return p(x) && q(x);
+	};
+};


### PR DESCRIPTION
This implements the filter.filter, map.map, and filter.map fusion from #85.  I moved the Map and Filter sources to lib/fusion, since Map needs to import Filter now.  I also added FilterMap which fuses a filter and a map.  It can be further fused with subsequent map steps on the right.

I'm still not crazy about the `instanceof` checks, but they're fairly obvious, and I can't see a better way atm--definitely open to suggestions (`source.constructor === Map` ???).  The impact of the `instanceof` checks shouldn't even be noticeable since they happen at stream creation time.  The benefit of the fusion at propagation time far outweighs it.