### PR TITLE
Clarify stream end signal value

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -922,6 +922,7 @@ End signal value considerations:
 stream:                 -2-4--5-6-8->
 stream.takeWhile(even): -2-4-|5|
 
+// end signal value is re-transmitted as-is (it is not passed to the predicate)
 stream:                 -2-4-6-8-|11|
 stream.takeWhile(even): -2-4-6-8-|11|
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -980,15 +980,32 @@ Alias: **skipUntil**
 ####`stream.since(startSignal) -> Stream`
 ####`most.since(startSignal, stream) -> Stream`
 
-Create a new stream containing all events after `startSignal` emits an event.  End signal value on the result stream will be the same as on the input stream.
+Create a new stream containing all events after `startSignal` emits an event.
+
+End signal value considerations:
+
+* if `startSignal` stream fires a normal event before `stream` ends then end signal value on the result stream will be the same as on the input stream.
+* if `startSignal` stream fires a normal event after `stream` ends then end signal value on the result stream will be the last normal event from the input stream.
+* if `startSignal` does not emit any normal event, then the returned stream will not emit any normal event and will end as soon as `startSignal` ends with the end signal value of `startSignal`'s.
 
 ```
-stream:                    -a-b-c-d-e-f->
+stream:                    -a-b-c-d-e-f-|g|
 startSignal:               ------z->
-stream.since(startSignal): -------d-e-f->
+stream.since(startSignal): -------d-e-f-|g|
+
+stream:                    -a-b-c-d-e-f-|g|
+startSignal:               -------------------z->
+stream.since(startSignal): ------------------|f|
+
+stream:                    -a-b-c-d-e-f->
+startSignal:               -------|S|
+stream.since(startSignal): -------|S|
+
+stream:                    -a-b-c-d-e-f->
+startSignal:               ------------->
+stream.since(startSignal): ------------->
 ```
 
-If `startSignal` is empty or never emits an event, then the returned stream will be an infinite empty stream (even if the source stream is finite).
 
 ```js
 // Start logging mouse events when the user clicks.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1053,7 +1053,7 @@ most.fromEvent('mousemove', document)
 ####`stream.loop(stepper, seed) -> Stream`
 ####`most.loop(stepper, seed, stream) -> Stream`
 
-Create a feedback loop that emits one value and feeds back another to be used in the next iteration.
+Create a feedback loop that emits one value and feeds back another to be used in the next iteration.  End signal value of the result stream will be a seed returned from the last invocation of `stepper`. `stepper` is not invoked for the end signal value of the input `stream`.
 
 It allows you to maintain and update a "state" (aka feedback, aka `seed` for the next iteration) while emitting a different value.  In contrast, [`scan`](#scan) feeds back and emits the same value.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -260,7 +260,9 @@ The unfolding function accepts a seed value and must return a tuple: `{value:*, 
 
 * `tuple.value` will be emitted as an event.
 * `tuple.seed` will be passed to the next invocation of the unfolding function.
-* `tuple.done` can be used to stop unfolding.  When `tuple.done == true`, unfolding will stop.
+* `tuple.done` can be used to stop unfolding.  When `tuple.done == true`, unfolding will stop.  Additionally, when `tuple.done == true`:
+	* `tuple.value` will be used as the stream's end signal value.  It *will not* appear as a normal event in the stream.
+ 	* `tuple.seed` will be ignored
 
 Note that if the unfolding function never returns a tuple with `tuple.done == true`, the stream will be infinite.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -873,8 +873,8 @@ stream.takeWhile(even): -2-4-|
 
 ### skipWhile
 
-####`stream.takeWhile(predicate) -> Stream`
-####`most.takeWhile(predicate, stream) -> Stream`
+####`stream.skipWhile(predicate) -> Stream`
+####`most.skipWhile(predicate, stream) -> Stream`
 
 Create a new stream containing all events after `predicate` returns false.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -980,13 +980,7 @@ Alias: **skipUntil**
 ####`stream.since(startSignal) -> Stream`
 ####`most.since(startSignal, stream) -> Stream`
 
-Create a new stream containing all events after `startSignal` emits an event.
-
-End signal value considerations:
-
-* if `startSignal` stream fires a normal event before `stream` ends then end signal value on the result stream will be the same as on the input stream.
-* if `startSignal` stream fires a normal event after `stream` ends then end signal value on the result stream will be the last normal event from the input stream.
-* if `startSignal` does not emit any normal event, then the returned stream will not emit any normal event and will end as soon as `startSignal` ends with the end signal value of `startSignal`'s.
+Create a new stream containing all events after `startSignal` emits an event.  The result stream will end at the same time as the input stream ends.  End signal value on the result stream will be the same as on input stream.
 
 ```
 stream:                    -a-b-c-d-e-f-|g|
@@ -995,11 +989,15 @@ stream.since(startSignal): -------d-e-f-|g|
 
 stream:                    -a-b-c-d-e-f-|g|
 startSignal:               -------------------z->
-stream.since(startSignal): ------------------|f|
+stream.since(startSignal): -------------|g|
 
-stream:                    -a-b-c-d-e-f->
+stream:                    -a-b-|c|
+startSignal:               ---------|S|
+stream.since(startSignal): -----|c|
+
+stream:                    -a-b-c-d-e-f-|g|
 startSignal:               -------|S|
-stream.since(startSignal): -------|S|
+stream.since(startSignal): -------------|g|
 
 stream:                    -a-b-c-d-e-f->
 startSignal:               ------------->

--- a/docs/api.md
+++ b/docs/api.md
@@ -884,7 +884,7 @@ stream:         -a-b|c|
 stream.take(3): -a-b|c|
 ```
 
-If `stream` contains fewer than `n` events, the returned stream will be effectively equivalent to `stream` (including end signal value).
+If `stream` contains fewer than `n` events, the returned stream will be equivalent to `stream`.
 
 ### skip
 
@@ -962,7 +962,7 @@ endSignal:               ---------------z->
 stream.until(endSignal): -a-b-c-d-|e|
 ```
 
-If `endSignal` is empty or never emits an event or emits it after the input stream finishes, then the returned stream will be effectively equivalent to `stream`.
+If `endSignal` is empty or never emits an event or emits it after the input stream finishes, then the returned stream will be equivalent to `stream`.
 
 ```js
 // Log mouse events until the user clicks. Note that DOM event handlers will

--- a/docs/api.md
+++ b/docs/api.md
@@ -1028,7 +1028,7 @@ Alias: **forEach**
 ####`most.observe(f, stream) -> Promise`
 ####`most.forEach(f, stream) -> Promise`
 
-Start consuming events from `stream`, processing each with `f`.  The returned promise will fulfill after all the events have been consumed having resolution value of end signal value (if present), or will reject if the stream fails and the [error is not handled](#handling-errors).
+Start consuming events from `stream`, processing each with `f`.  The returned promise will fulfill with the end signal value (or null if not present) after all the events have been consumed., or will reject if the stream fails and the [error is not handled](#handling-errors).
 
 ```js
 // Log mouse movements until the user clicks, then stop.

--- a/docs/api.md
+++ b/docs/api.md
@@ -127,7 +127,7 @@ A stream that emits `a`, then `b`, then `c`, then nothing, then `d`, then `e`, t
 most.of(x): x|
 ```
 
-Create a stream containing only x.  End signal value of the stream is always `null`.
+Create a stream containing only x.  End signal value of the stream is always `undefined`.
 
 ```js
 var stream = most.of('hello');
@@ -143,7 +143,7 @@ promise:                   ----a
 most.fromPromise(promise): ----a|
 ```
 
-Create a stream containing the outcome of a promise.  If the promise fulfills, the stream will contain the promise's value.  If the promise rejects, the stream will be in an error state with the promise's rejection reason as its error.  See [flatMapError](#flatmaperror) for error recovery.  End signal value of the stream is always `null`.
+Create a stream containing the outcome of a promise.  If the promise fulfills, the stream will contain the promise's value.  If the promise rejects, the stream will be in an error state with the promise's rejection reason as its error.  See [flatMapError](#flatmaperror) for error recovery.  End signal value of the stream is always `undefined`.
 
 ### most.from
 
@@ -157,7 +157,7 @@ Create a stream containing all items from an iterable.  The iterable can be an A
 
 End signal value considerations:
 
-* For Arrays it is always `null`
+* For Arrays it is always `undefined`
 * For iterables it is `tuple.value` of the `tuple` returned by `next()` that has `tuple.done` set to true.
   * For ES6 generators it will be a value returned (*not* yielded) by the generator.
 
@@ -236,7 +236,7 @@ Create an infinite stream containing events that arrive every `period` milliseco
 most.empty(): |
 ```
 
-Create an already-ended stream containing no events.  End signal value of the stream is always `null`.
+Create an already-ended stream containing no events.  End signal value of the stream is always `undefined`.
 
 ### most.never
 
@@ -1092,7 +1092,7 @@ Alias: **forEach**
 ####`most.observe(f, stream) -> Promise`
 ####`most.forEach(f, stream) -> Promise`
 
-Start consuming events from `stream`, processing each with `f`.  The returned promise will fulfill with the end signal value (or null if not present) after all the events have been consumed., or will reject if the stream fails and the [error is not handled](#handling-errors).
+Start consuming events from `stream`, processing each with `f`.  The returned promise will fulfill with the end signal value (or `undefined` if not present) after all the events have been consumed., or will reject if the stream fails and the [error is not handled](#handling-errors).
 
 ```js
 // Log mouse movements until the user clicks, then stop.


### PR DESCRIPTION
This PR includes documentation of end signal value. It supersedes #104 as the commit is included here too (it was rebased to current master). There is still some work to be done in the topic of end signal value as only simple cases were mentioned here. All the operations on streams need to be evaluated in terms of end signal value, but it was beyond my expertise (now). I'm opening new issue to handle the rest.