### PR TITLE
Add missing closing paren to `until` example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -894,7 +894,7 @@ If `endSignal` is empty or never emits an event, then the returned stream will b
 // Log mouse events until the user clicks. Note that DOM event handlers will
 // automatically be unregistered.
 most.fromEvent('mousemove', document)
-	.until(most.fromEvent('click', document)
+	.until(most.fromEvent('click', document))
 	.forEach(console.log.bind(console));
 ```
 


### PR DESCRIPTION
I was unable to understand the documentation until I added this closing paren.

Thanks for your work on this library. It and the fantasy-land spec have been good footholds for understanding the underlying principles, and I'm still digging in.