### PR TITLE
Update to new transducer protocol

### DIFF
--- a/lib/combinator/transduce.js
+++ b/lib/combinator/transduce.js
@@ -24,18 +24,19 @@ function Transduce(transducer, source) {
 
 Transduce.prototype.run = function(sink, scheduler) {
 	var xf = this.transducer(new Transformer(sink));
-	return this.source.run(new TransduceSink(xf, sink), scheduler);
+	return this.source.run(new TransduceSink(getTxHandler(xf), sink), scheduler);
 };
 
-function TransduceSink(xf, sink) {
-	this.xf = xf;
+function TransduceSink(adapter, sink) {
+	this.xf = adapter;
 	this.sink = sink;
 }
 
 TransduceSink.prototype.event = function(t, x) {
 	var next = this.xf.step(t, x);
-	return next != null && next.__transducers_reduced__
-		? this.sink.end(t, next.value)
+
+	return this.xf.isReduced(next)
+		? this.sink.end(t, this.xf.getResult(next))
 		: next;
 };
 
@@ -52,15 +53,71 @@ function Transformer(sink) {
 	this.sink = sink;
 }
 
-Transformer.prototype.init = function() {};
+Transformer.prototype['@@transducer/init'] = Transformer.prototype.init = function() {};
 
-Transformer.prototype.step = function(t, x) {
+Transformer.prototype['@@transducer/step'] = Transformer.prototype.step = function(t, x) {
 	if(!isNaN(t)) {
 		this.time = Math.max(t, this.time);
 	}
 	return this.sink.event(this.time, x);
 };
 
-Transformer.prototype.result = function(x) {
+Transformer.prototype['@@transducer/result'] = Transformer.prototype.result = function(x) {
 	return this.sink.end(this.time, x);
+};
+
+/**
+ * Given an object supporting the new or legacy transducer protocol,
+ * create an adapter for it.
+ * @param {object} tx transform
+ * @returns {TxAdapter|LegacyTxAdapter}
+ */
+function getTxHandler(tx) {
+	return typeof tx['@@transducer/step'] === 'function'
+		? new TxAdapter(tx)
+		: new LegacyTxAdapter(tx);
+}
+
+/**
+ * Adapter for new official transducer protocol
+ * @param {object} tx transform
+ * @constructor
+ */
+function TxAdapter(tx) {
+	this.tx = tx;
+}
+
+TxAdapter.prototype.step = function(t, x) {
+	return this.tx['@@transducer/step'](t, x);
+};
+TxAdapter.prototype.result = function(x) {
+	return this.tx['@@transducer/result'](x);
+};
+TxAdapter.prototype.isReduced = function(x) {
+	return x != null && x['@@transducer/reduced'];
+};
+TxAdapter.prototype.getResult = function(x) {
+	return x['@@transducer/value'];
+};
+
+/**
+ * Adapter for older transducer protocol
+ * @param {object} tx transform
+ * @constructor
+ */
+function LegacyTxAdapter(tx) {
+	this.tx = tx;
+}
+
+LegacyTxAdapter.prototype.step = function(t, x) {
+	return this.tx.step(t, x);
+};
+LegacyTxAdapter.prototype.result = function(x) {
+	return this.tx.result(x);
+};
+LegacyTxAdapter.prototype.isReduced = function(x) {
+	return x != null && x.__transducers_reduced__;
+};
+LegacyTxAdapter.prototype.getResult = function(x) {
+	return x.value;
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "buster": "~0.7",
     "jshint": "~2",
-    "transducers-js": "~0.4"
+    "transducers-js": "^0.4.158"
   },
   "dependencies": {
     "when": "^3.7.0"


### PR DESCRIPTION
This supports both the legacy and new protocols.  My plan is to release this as 0.13.1, and then remove support for the legacy protocol in 0.14.0 (which may actually be 1.0)

Close #114 