### PR TITLE
Improve EventEmitter and EventTarget subscription.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -317,7 +317,9 @@ most.fromEvent(eventType, source): -a--b-c---d->
 
 Create a stream containing events from the provided [EventTarget](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget), such as a DOM element, or [EventEmitter](http://nodejs.org/api/events.html#events_class_events_eventemitter).  This provides a simple way to coerce existing event sources into streams.
 
-Note that when the stream ends (for example, by using [take](#take), [takeUntil](#until), etc.), it will automatically be disconnected from the event source.  For example, in the case of DOM events, the underlying DOM event listener will be removed automatically.
+When the stream ends (for example, by using [take](#take), [takeUntil](#until), etc.), it will automatically be disconnected from the event source.  For example, in the case of DOM events, the underlying DOM event listener will be removed automatically.
+
+Note on EventEmitter: EventEmitters and EventTargets, such as DOM nodes, behave differently in that EventEmitter allows events to be delivered in the same tick as a listener is added.  When using EventEmitter, `most.fromEvent`, will *ensure asynchronous event delivery*, thereby preventing hazards of "maybe sync, maybe async" (aka zalgo) event delivery.
 
 ```js
 var clicks = most.fromEvent('click', document.querySelector('.the-button'));

--- a/lib/scheduler/PropagateTask.js
+++ b/lib/scheduler/PropagateTask.js
@@ -21,6 +21,10 @@ PropagateTask.end = function(value, sink) {
 	return new PropagateTask(end, value, sink);
 };
 
+PropagateTask.error = function(value, sink) {
+	return new PropagateTask(error, value, sink);
+};
+
 PropagateTask.prototype.dispose = function() {
 	this.active = false;
 };
@@ -38,6 +42,10 @@ PropagateTask.prototype.error = function(t, e) {
 	}
 	this.sink.error(t, e);
 };
+
+function error(t, e, sink) {
+	sink.error(t, e);
+}
 
 function emit(t, x, sink) {
 	sink.event(t, x);

--- a/lib/source/AsyncSource.js
+++ b/lib/source/AsyncSource.js
@@ -1,0 +1,47 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var base = require('../base');
+var resolve = require('../Promise').resolve;
+var Disposable = require('../disposable/Disposable');
+
+module.exports = AsyncSource;
+
+function AsyncSource(source) {
+	this.source = source;
+}
+
+AsyncSource.prototype.run = function(sink, scheduler) {
+	var task = new StartAsyncTask(this.source, sink, scheduler);
+	var disposable = scheduler.asap(task);
+
+	return new Disposable(asyncDispose, disposable);
+};
+
+function asyncDispose(disposable) {
+	return resolve(disposable).then(dispose);
+}
+
+function dispose(disposable) {
+	if(disposable === void 0) {
+		return;
+	}
+	return disposable.dispose();
+}
+
+function StartAsyncTask(source, sink, scheduler) {
+	this.source = source;
+	this.sink = sink;
+	this.scheduler = scheduler;
+}
+
+StartAsyncTask.prototype.run = function() {
+	return this.source.run(this.sink, this.scheduler);
+};
+
+StartAsyncTask.prototype.error = function(t, e) {
+	this.sink.error(t, e);
+};
+
+StartAsyncTask.prototype.dispose = base.noop;

--- a/lib/source/MulticastSource.js
+++ b/lib/source/MulticastSource.js
@@ -16,8 +16,7 @@ function MulticastSource(source) {
 MulticastSource.prototype.run = function(sink, scheduler) {
 	var n = this.sink.add(sink);
 	if(n === 1) {
-		var task = new StartMulticastTask(this.source, this.sink, scheduler);
-		this._disposable = scheduler.asap(task);
+		this._disposable = this.source.run(this.sink, scheduler);
 	}
 
 	return new MulticastDisposable(this, sink);
@@ -33,22 +32,6 @@ function dispose(disposable) {
 	}
 	return disposable.dispose();
 }
-
-function StartMulticastTask(source, sink, scheduler) {
-	this.source = source;
-	this.sink = sink;
-	this.scheduler = scheduler;
-}
-
-StartMulticastTask.prototype.run = function() {
-	return this.source.run(this.sink, this.scheduler);
-};
-
-StartMulticastTask.prototype.error = function(t, e) {
-	this.sink.error(t, e);
-};
-
-StartMulticastTask.prototype.dispose = base.noop;
 
 function MulticastDisposable(source, sink) {
 	this.source = source;

--- a/lib/source/create.js
+++ b/lib/source/create.js
@@ -5,12 +5,13 @@
 var Stream = require('../Stream');
 var Disposable = require('../disposable/Disposable');
 var MulticastSource = require('./MulticastSource');
+var AsyncSource = require('./AsyncSource');
 var noop = require('../base').noop;
 
 exports.create = create;
 
 function create(run) {
-	return new Stream(new MulticastSource(new SubscriberSource(run)));
+	return new Stream(new MulticastSource(new AsyncSource(new SubscriberSource(run))));
 }
 
 function SubscriberSource(subscribe) {

--- a/lib/source/fromEvent.js
+++ b/lib/source/fromEvent.js
@@ -4,6 +4,7 @@
 
 var Stream = require('../Stream');
 var MulticastSource = require('./MulticastSource');
+var PropagateTask = require('../scheduler/PropagateTask');
 var base = require('../base');
 
 exports.fromEvent = fromEvent;
@@ -24,7 +25,16 @@ function fromEvent(event, source) {
  * @deprecated Use fromEvent(...).filter or fromEvent(...).tap instead
  */
 function fromEventWhere(predicate, event, source) {
-	return new Stream(new MulticastSource(new EventSource(predicate, event, source)));
+	var s;
+	if(typeof source.addEventListener === 'function') {
+		s = new MulticastSource(new EventSource(predicate, event, source));
+	} else if(typeof source.addListener === 'function') {
+		s = new EventEmitterSource(predicate, event, source);
+	} else {
+		throw new Error('source must support addEventListener or addListener');
+	}
+
+    return new Stream(s);
 }
 
 function EventSource(where, event, source) {
@@ -34,10 +44,10 @@ function EventSource(where, event, source) {
 }
 
 EventSource.prototype.run = function(sink, scheduler) {
-	return new EventSink(this.where, this.event, this.source, sink, scheduler);
+	return new EventAdapter(this.where, this.event, this.source, sink, scheduler);
 };
 
-function EventSink(where, event, source, sink, scheduler) {
+function EventAdapter(where, event, source, sink, scheduler) {
 	this.event = event;
 	this.source = source;
 	this.sink = sink;
@@ -54,47 +64,78 @@ function EventSink(where, event, source, sink, scheduler) {
 	this._addEvent = this._init(addEvent, event, source);
 }
 
-EventSink.prototype._init = function(addEvent, event, source) {
+EventAdapter.prototype._init = function(addEvent, event, source) {
+	source.addEventListener(event, addEvent, false);
+	return addEvent;
+};
+
+EventAdapter.prototype.dispose = function() {
+	if (typeof this.source.removeEventListener !== 'function') {
+		throw new Error('source must support removeEventListener or removeListener');
+	}
+
+	this.source.removeEventListener(this.event, this._addEvent, false);
+};
+
+function EventEmitterSource(where, event, source) {
+	this.where = where;
+	this.event = event;
+	this.source = source;
+}
+
+EventEmitterSource.prototype.run = function(sink, scheduler) {
+	return new EventEmitterAdapter(this.where, this.event, this.source, sink, scheduler);
+};
+
+function EventEmitterAdapter(where, event, source, sink, scheduler) {
+	this.event = event;
+	this.source = source;
+	this.sink = sink;
+	this.where = where;
+
+	var self = this;
+	function addEvent(ev) {
+		if(self.where(ev) === false) {
+			return;
+		}
+		// NOTE: Because EventEmitter allows events in the same call stack as
+		// a listener is added, use the scheduler to buffer all events
+		// until the stack clears, then propagate.
+		scheduler.asap(new PropagateTask(tryEvent, ev, self.sink));
+	}
+
+	this._addEvent = this._init(addEvent, event, source);
+}
+
+EventEmitterAdapter.prototype._init = function(addEvent, event, source) {
 	var doAddEvent = addEvent;
 
-	if(typeof source.addEventListener === 'function') {
-		source.addEventListener(event, doAddEvent, false);
+	// EventEmitter supports varargs (eg: emitter.emit('event', a, b, c, ...)) so
+	// have to support it here by turning into an array
+	doAddEvent = function addVarargs(a) {
+		return arguments.length > 1 ? addEvent(base.copy(arguments)) : addEvent(a);
+	};
 
-	} else if(typeof source.addListener === 'function') {
-		// EventEmitter supports varargs (eg: emitter.emit('event', a, b, c, ...)) so
-		// have to support it here by turning into an array
-		doAddEvent = function addVarargs(a) {
-			return arguments.length > 1 ? addEvent(base.copy(arguments)) : addEvent(a);
-		};
-
-		source.addListener(event, doAddEvent);
-
-	} else {
-		throw new Error('source must support addEventListener or addListener');
-	}
+	source.addListener(event, doAddEvent);
 
 	return doAddEvent;
 };
 
-EventSink.prototype.dispose = function() {
-	if(typeof this.source.removeEventListener === 'function') {
-		this.source.removeEventListener(this.event, this._addEvent, false);
-
-	} else if(typeof this.source.removeListener === 'function') {
-		this.source.removeListener(this.event, this._addEvent);
-
-	} else {
+EventEmitterAdapter.prototype.dispose = function() {
+	if (typeof this.source.removeListener !== 'function') {
 		throw new Error('source must support removeEventListener or removeListener');
 	}
+
+	this.source.removeListener(this.event, this._addEvent);
 };
 
 function always() {
 	return true;
 }
 
-function tryEvent (t, ev, sink) {
+function tryEvent (t, x, sink) {
 	try {
-		sink.event(t, ev);
+		sink.event(t, x);
 	} catch(e) {
 		sink.error(t, e);
 	}


### PR DESCRIPTION
Extract AsyncSource from MulticastSource. fromEvent now subscribes synchronously, but maintains call stack safety for EventEmitter by buffering EventEmitter events into the next tick.

Close #116