### PR TITLE
Add ES7 Observable strawman

### DIFF
--- a/lib/Observable.js
+++ b/lib/Observable.js
@@ -1,0 +1,32 @@
+var Stream = require('./Stream');
+var ObservableSource = require('./source/ObservableSource');
+var MulticastSource = require('./source/MulticastSource');
+var AsyncSource = require('./source/AsyncSource');
+var scheduler = require('./scheduler/defaultScheduler');
+
+exports.create = createObservable;
+exports.observer = observer;
+
+function createObservable(generator) {
+	return new Stream(new MulticastSource(new AsyncSource(new ObservableSource(generator))));
+}
+
+function observer(handler, stream) {
+	return stream.source.run(new ObserverSink(handler), scheduler);
+}
+
+function ObserverSink(handler) {
+	this.handler = handler;
+}
+
+ObserverSink.prototype.event = function(t, x) {
+	this.handler.next(x);
+};
+
+ObserverSink.prototype.end = function(t, x) {
+	this.handler['return'](x);
+};
+
+ObserverSink.prototype.error = function(t, e) {
+	this.handler['throw'](e);
+};

--- a/lib/source/ObservableSource.js
+++ b/lib/source/ObservableSource.js
@@ -1,0 +1,46 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+module.exports = ObservableSource;
+
+function ObservableSource(subscribe) {
+	this._subscribe = subscribe;
+}
+
+ObservableSource.prototype.run = function(sink, scheduler) {
+	return this._subscribe(new ObservableProducer(sink, scheduler));
+};
+
+function ObservableProducer(sink, scheduler) {
+	this.sink = sink;
+	this.scheduler = scheduler;
+}
+
+ObservableProducer.prototype.next = function(x) {
+	tryEvent(this.scheduler.now(), x, this.sink);
+};
+
+ObservableProducer.prototype['return'] = function(x) {
+	tryEnd(this.scheduler.now(), x, this.sink);
+};
+
+ObservableProducer.prototype['throw'] = function(e) {
+	this.sink.error(this.scheduler.now(), e);
+};
+
+function tryEvent(t, x, sink) {
+	try {
+		sink.event(t, x);
+	} catch(e) {
+		sink.error(t, e);
+	}
+}
+
+function tryEnd(t, x, sink) {
+	try {
+		sink.end(t, x);
+	} catch(e) {
+		sink.error(t, e);
+	}
+}

--- a/lib/source/create.js
+++ b/lib/source/create.js
@@ -4,6 +4,7 @@
 
 var Stream = require('../Stream');
 var Disposable = require('../disposable/Disposable');
+var ObservableSource = require('./ObservableSource');
 var MulticastSource = require('./MulticastSource');
 var AsyncSource = require('./AsyncSource');
 var noop = require('../base').noop;
@@ -11,43 +12,24 @@ var noop = require('../base').noop;
 exports.create = create;
 
 function create(run) {
-	return new Stream(new MulticastSource(new AsyncSource(new SubscriberSource(run))));
-}
+	return new Stream(new MulticastSource(new AsyncSource(new ObservableSource(subscribe))));
 
-function SubscriberSource(subscribe) {
-	this._subscribe = subscribe;
-}
+	function subscribe(generator) {
+		var unsubscribe = run(add, end, error);
 
-SubscriberSource.prototype.run = function(sink, scheduler) {
-	var unsubscribe = this._subscribe(add, end, error);
+		return new Disposable(typeof unsubscribe === 'function' ? unsubscribe : noop);
 
-	return new Disposable(typeof unsubscribe === 'function' ? unsubscribe : noop);
+		function add(x) {
+			return generator.next(x);
+		}
 
-	function add(x) {
-		tryEvent(scheduler.now(), x, sink);
-	}
+		function end(x) {
+			return generator['return'](x);
+		}
 
-	function end(x) {
-		tryEnd(scheduler.now(), x, sink);
-	}
+		function error(e) {
+			return generator['throw'](e);
+		}
 
-	function error(e) {
-		sink.error(scheduler.now(), e);
-	}
-};
-
-function tryEvent(t, x, sink) {
-	try {
-		sink.event(t, x);
-	} catch(e) {
-		sink.error(t, e);
-	}
-}
-
-function tryEnd(t, x, sink) {
-	try {
-		sink.end(t, x);
-	} catch(e) {
-		sink.error(t, e);
 	}
 }

--- a/most.js
+++ b/most.js
@@ -22,6 +22,28 @@ exports.from     = from;
 exports.periodic = periodic;
 
 //-----------------------------------------------------------------------
+// ES7 Observable interface
+
+var Observable = require('./lib/Observable');
+
+/**
+ * ES7 Observable (callable with or without new).  Basically, a thin
+ * wrapper around Stream to present an ES7 compatible API.
+ * @param {function({next, return, throw}):{dispose:function}} producer
+ * @constructor
+ */
+exports.Observable = Observable.create;
+
+/**
+ * ES7 style observation
+ * @param {{next:function(x:*), return:function(x:*), throw:function(e:*)}} observer
+ * @return {{dispose:function():*}} subscription which can be disposed
+ */
+Stream.prototype['@@observer'] = Stream.prototype.observer = function(observer) {
+	return Observable.observer(observer, this);
+};
+
+//-----------------------------------------------------------------------
 // Creating
 
 var create = require('./lib/source/create');


### PR DESCRIPTION
For Discussion.

This provides an ES7 Observable(producer) constructor, as most.Observable, as well as `observable['@@observer']` and observable.observer methods for observing.

See:

* https://github.com/jhusain/asyncgenerator
* https://github.com/cujojs/most/pull/72#issuecomment-91162216

Example:

```js
var Observable = require('most').Observable;

var observable = new Observable(function(generator) {
	console.log(1);
	generator.next(2);
});

observable['@@observer']({
	next: function (value) {
		console.log(value);
	}
});

console.log(3);

// Logs 3 1 2
```