### PR TITLE
Rename distinct -> skipRepeats

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -35,8 +35,8 @@ most.js API
 	* [tap](#tap)
 1. Filtering streams
 	* [filter](#filter)
-	* [distinct](#distinct)
-	* [distinctBy](#distinctby)
+	* [skipRepeats](#skipRepeats)
+	* [skipRepeatsWith](#skipRepeatsWith)
 1. Transducer support
 	* [transduce](#transduce)
 1. Slicing streams
@@ -767,30 +767,34 @@ stream:              -1-2-3-4->
 stream.filter(even): ---2---4->
 ```
 
-### distinct
+### skipRepeats
 
-####`stream.distinct() -> Stream`
-####`most.distinct(stream) -> Stream`
+**Deprecated alias:** `distinct`
 
-Create a new stream with *adjacent duplicates* removed.
+####`stream.skipRepeats() -> Stream`
+####`most.skipRepeats(stream) -> Stream`
+
+Create a new stream with *adjacent* repeated events removed.
 
 ```
 stream:            -1-2-2-3-4-4-5->
-stream.distinct(): -1-2---3-4---5->
+stream.skipRepeats(): -1-2---3-4---5->
 ```
 
 Note that `===` is used to identify duplicate items.  To use a different comparison, use [`distinctBy`](#distinctby)
 
-### distinctBy
+### skipRepeatsWith
 
-####`stream.distinctBy(equals) -> Stream`
-####`most.distinctBy(equals, stream) -> Stream`
+**Deprecated alias:** `distinctBy`
 
-Create a new stream with *adjacent duplicates* removed, using the provided `equals` function.
+####`stream.skipRepeatsWith(equals) -> Stream`
+####`most.skipRepeatsWith(equals, stream) -> Stream`
+
+Create a new stream with *adjacent* repeated events removed, using the provided `equals` function.
 
 ```
 stream:                              -a-b-B-c-D-d-e->
-stream.distinctBy(equalsIgnoreCase): -a-b---c-D---e->
+stream.skipRepeatsWith(equalsIgnoreCase): -a-b---c-D---e->
 ```
 
 The `equals` function should accept two values and return truthy if the two values are equal, or falsy if they are not equal.

--- a/lib/combinator/filter.js
+++ b/lib/combinator/filter.js
@@ -7,8 +7,8 @@ var Sink = require('../sink/Pipe');
 var Filter = require('../fusion/Filter');
 
 exports.filter = filter;
-exports.distinct = distinct;
-exports.distinctBy = distinctBy;
+exports.skipRepeats = skipRepeats;
+exports.skipRepeatsWith = skipRepeatsWith;
 
 /**
  * Retain only items matching a predicate
@@ -21,44 +21,44 @@ function filter(p, stream) {
 }
 
 /**
- * Remove adjacent duplicates, using === to detect duplicates
- * @param {Stream} stream stream from which to omit adjacent duplicates
- * @returns {Stream} stream with no adjacent duplicates
+ * Skip repeated events, using === to detect duplicates
+ * @param {Stream} stream stream from which to omit repeated events
+ * @returns {Stream} stream without repeated events
  */
-function distinct(stream) {
-	return distinctBy(same, stream);
+function skipRepeats(stream) {
+	return skipRepeatsWith(same, stream);
 }
 
 /**
- * Remove adjacent duplicates using the provided equals function to detect duplicates
- * @param {?function(a:*, b:*):boolean} equals optional function to compare items.
- * @param {Stream} stream stream from which to omit adjacent duplicates
- * @returns {Stream} stream with no adjacent duplicates
+ * Skip repeated events using the provided equals function to detect duplicates
+ * @param {function(a:*, b:*):boolean} equals optional function to compare items
+ * @param {Stream} stream stream from which to omit repeated events
+ * @returns {Stream} stream without repeated events
  */
-function distinctBy(equals, stream) {
-	return new Stream(new Distinct(equals, stream.source));
+function skipRepeatsWith(equals, stream) {
+	return new Stream(new SkipRepeats(equals, stream.source));
 }
 
-function Distinct(equals, source) {
+function SkipRepeats(equals, source) {
 	this.equals = equals;
 	this.source = source;
 }
 
-Distinct.prototype.run = function(sink, scheduler) {
-	return this.source.run(new DistinctSink(this.equals, sink), scheduler);
+SkipRepeats.prototype.run = function(sink, scheduler) {
+	return this.source.run(new SkipRepeatsSink(this.equals, sink), scheduler);
 };
 
-function DistinctSink(equals, sink) {
+function SkipRepeatsSink(equals, sink) {
 	this.equals = equals;
 	this.sink = sink;
 	this.value = void 0;
 	this.init = true;
 }
 
-DistinctSink.prototype.end   = Sink.prototype.end;
-DistinctSink.prototype.error = Sink.prototype.error;
+SkipRepeatsSink.prototype.end   = Sink.prototype.end;
+SkipRepeatsSink.prototype.error = Sink.prototype.error;
 
-DistinctSink.prototype.event = function(t, x) {
+SkipRepeatsSink.prototype.event = function(t, x) {
 	if(this.init) {
 		this.init = false;
 		this.value = x;

--- a/most.js
+++ b/most.js
@@ -403,9 +403,9 @@ Stream.prototype.switch = Stream.prototype.switchLatest = function() {
 
 var filter = require('./lib/combinator/filter');
 
-exports.filter     = filter.filter;
-exports.distinct   = filter.distinct;
-exports.distinctBy = filter.distinctBy;
+exports.filter          = filter.filter;
+exports.skipRepeats     = exports.distinct   = filter.skipRepeats;
+exports.skipRepeatsWith = exports.distinctBy = filter.skipRepeatsWith;
 
 /**
  * Retain only items matching a predicate
@@ -419,22 +419,22 @@ Stream.prototype.filter = function(p) {
 };
 
 /**
- * Remove adjacent duplicates, using === to compare items
+ * Skip repeated events, using === to compare items
  * stream:           -abbcd-
  * distinct(stream): -ab-cd-
- * @returns {Stream} stream with no adjacent duplicates
+ * @returns {Stream} stream with no repeated events
  */
-Stream.prototype.distinct = function() {
-	return filter.distinct(this);
+Stream.prototype.skipRepeats = Stream.prototype.distinct = function() {
+	return filter.skipRepeats(this);
 };
 
 /**
- * Remove adjacent duplicates, using supplied equals function to compare items
- * @param {function(a:*, b:*):boolean} equals function to compare items.
- * @returns {Stream} stream with no adjacent duplicates
+ * Skip repeated events, using supplied equals function to compare items
+ * @param {function(a:*, b:*):boolean} equals function to compare items
+ * @returns {Stream} stream with no repeated events
  */
-Stream.prototype.distinctBy = function(equals) {
-	return filter.distinctBy(equals, this);
+Stream.prototype.skipRepeatsWith = Stream.prototype.distinctBy = function(equals) {
+	return filter.skipRepeatsWith(equals, this);
 };
 
 //-----------------------------------------------------------------------

--- a/test/filter-test.js
+++ b/test/filter-test.js
@@ -21,10 +21,10 @@ describe('filter', function() {
 	});
 });
 
-describe('distinct', function() {
+describe('skipRepeats', function() {
 
-	it('should return a stream with adjacent duplicates removed', function() {
-		var stream = filter.distinct(fromArray([1, 2, 2, 3, 4, 4]));
+	it('should return a stream with repeated events removed', function() {
+		var stream = filter.skipRepeats(fromArray([1, 2, 2, 3, 4, 4]));
 		return reduce(function(a, x) {
 				a.push(x);
 				return a;
@@ -36,14 +36,14 @@ describe('distinct', function() {
 
 });
 
-describe('distinctBy', function() {
+describe('skipRepeatsWith', function() {
 
-	it('should use provided comparator to remove adjacent duplicates', function() {
+	it('should use provided comparator to remove repeated events', function() {
 		function eq(a, b) {
 			return a.toLowerCase() === b.toLowerCase();
 		}
 
-		var stream = filter.distinctBy(eq, fromArray(['a', 'b', 'B', 'c', 'D', 'd']));
+		var stream = filter.skipRepeatsWith(eq, fromArray(['a', 'b', 'B', 'c', 'D', 'd']));
 		return reduce(function(a, x) {
 				a.push(x);
 				return a;

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -35,3 +35,19 @@ describe('skipUntil', function() {
 		expect(most.Stream.prototype.skipUntil).toBe(most.Stream.prototype.since);
 	});
 });
+
+describe('distinct', function() {
+	it('should be an alias for skipRepeats', function() {
+		expect(typeof most.distinct).toBe('function');
+		expect(most.distinct).toBe(most.skipRepeats);
+		expect(most.Stream.prototype.distinct).toBe(most.Stream.prototype.skipRepeats);
+	});
+});
+
+describe('distinctBy', function() {
+	it('should be an alias for skipRepeatsWith', function() {
+		expect(typeof most.distinctBy).toBe('function');
+		expect(most.distinctBy).toBe(most.skipRepeatsWith);
+		expect(most.Stream.prototype.distinctBy).toBe(most.Stream.prototype.skipRepeatsWith);
+	});
+});


### PR DESCRIPTION
Use new name `skipRepeats` and `skipRepeatsWith`.  Deprecate `distinct` and `distinctBy`.

Close #94 