### PR TITLE
Simplify switch() using until() and concurrentMergeMap()

### DIFF
--- a/lib/combinator/concatMap.js
+++ b/lib/combinator/concatMap.js
@@ -2,7 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var concurrentMergeMap = require('./concurrentMergeMap').concurrentMergeMap;
+var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
+var map = require('./transform').map;
 
 exports.concatMap = concatMap;
 
@@ -18,5 +19,5 @@ exports.concatMap = concatMap;
  * @returns {Stream} new stream containing all events from each stream returned by f
  */
 function concatMap(f, stream) {
-	return concurrentMergeMap(f, 1, stream);
+	return mergeConcurrently(1, map(f, stream));
 }

--- a/lib/combinator/flatMap.js
+++ b/lib/combinator/flatMap.js
@@ -2,8 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var concurrentMergeMap = require('./concurrentMergeMap').concurrentMergeMap;
-var identity = require('../base').identity;
+var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
+var map = require('./transform').map;
 
 exports.flatMap = flatMap;
 exports.join = join;
@@ -16,7 +16,7 @@ exports.join = join;
  * @returns {Stream} new stream containing all events from each stream returned by f
  */
 function flatMap(f, stream) {
-	return concurrentMergeMap(f, Infinity, stream);
+	return join(map(f, stream));
 }
 
 /**
@@ -26,5 +26,5 @@ function flatMap(f, stream) {
  * @returns {Stream<X>} new stream containing all events of all inner streams
  */
 function join(stream) {
-	return flatMap(identity, stream);
+	return mergeConcurrently(Infinity, stream);
 }

--- a/lib/combinator/merge.js
+++ b/lib/combinator/merge.js
@@ -4,7 +4,7 @@
 
 var empty = require('../Stream').empty;
 var fromArray = require('../source/fromArray').fromArray;
-var join = require('./flatMap').join;
+var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
 var copy = require('../base').copy;
 
 exports.merge = merge;
@@ -26,7 +26,8 @@ function merge(/*...streams*/) {
  * arbitrary order.
  */
 function mergeArray(streams) {
-	return streams.length === 0 ? empty()
-		 : streams.length === 1 ? streams[0]
-		 : join(fromArray(streams));
+	var l = streams.length;
+    return l === 0 ? empty()
+		 : l === 1 ? streams[0]
+		 : mergeConcurrently(l, fromArray(streams));
 }

--- a/lib/combinator/mergeConcurrently.js
+++ b/lib/combinator/mergeConcurrently.js
@@ -10,33 +10,22 @@ var Promise = require('../Promise');
 var resolve = Promise.resolve;
 var all = Promise.all;
 
-exports.concurrentMergeMap = concurrentMergeMap;
+exports.mergeConcurrently = mergeConcurrently;
 
-/**
- * Map each value in the stream to a new stream, and merge it into the
- * returned outer stream. Event arrival times are preserved.
- * @param {function(x:*):Stream} f chaining function, must return a Stream
- * @param {number} concurrency max number of streams to merge concurrently.  At most,
- *  this many inner streams will be active at one time.
- * @param {Stream} stream
- * @returns {Stream} new stream containing all events from each stream returned by f
- */
-function concurrentMergeMap(f, concurrency, stream) {
-	return new Stream(new MergeMap(f, concurrency, stream.source));
+function mergeConcurrently(concurrency, stream) {
+	return new Stream(new MergeConcurrently(concurrency, stream.source));
 }
 
-function MergeMap(f, concurrency, source) {
-	this.f = f;
+function MergeConcurrently(concurrency, source) {
 	this.concurrency = concurrency;
 	this.source = source;
 }
 
-MergeMap.prototype.run = function(sink, scheduler) {
-	return new Outer(this.f, this.concurrency, this.source, sink, scheduler);
+MergeConcurrently.prototype.run = function(sink, scheduler) {
+	return new Outer(this.concurrency, this.source, sink, scheduler);
 };
 
-function Outer(f, concurrency, source, sink, scheduler) {
-	this.f = f;
+function Outer(concurrency, source, sink, scheduler) {
 	this.concurrency = concurrency;
 	this.sink = sink;
 	this.scheduler = scheduler;
@@ -47,8 +36,7 @@ function Outer(f, concurrency, source, sink, scheduler) {
 }
 
 Outer.prototype.event = function(t, x) {
-	var f = this.f;
-	this._addInner(t, f(x));
+	this._addInner(t, x);
 };
 
 Outer.prototype._addInner = function(t, stream) {

--- a/lib/combinator/switch.js
+++ b/lib/combinator/switch.js
@@ -5,7 +5,8 @@
 var Stream = require('../Stream');
 var MulticastSource = require('../source/MulticastSource');
 var until = require('./timeslice').takeUntil;
-var concurrentMergeMap = require('./concurrentMergeMap').concurrentMergeMap;
+var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
+var map = require('./transform').map;
 
 exports.switch = switchLatest;
 
@@ -18,7 +19,7 @@ exports.switch = switchLatest;
 function switchLatest(stream) {
 	var upstream = new Stream(new MulticastSource(stream.source));
 
-	return concurrentMergeMap(untilNext, 1, upstream);
+	return mergeConcurrently(1, map(untilNext, upstream));
 
 	function untilNext(s) {
 		return until(upstream, s);

--- a/lib/combinator/switch.js
+++ b/lib/combinator/switch.js
@@ -3,8 +3,9 @@
 /** @author John Hann */
 
 var Stream = require('../Stream');
-var ChainDisposable = require('../disposable/ChainDisposable');
-var EmptyDisposable = require('../disposable/EmptyDisposable');
+var MulticastSource = require('../source/MulticastSource');
+var until = require('./timeslice').takeUntil;
+var concurrentMergeMap = require('./concurrentMergeMap').concurrentMergeMap;
 
 exports.switch = switchLatest;
 
@@ -15,97 +16,11 @@ exports.switch = switchLatest;
  * @returns {Stream} switching stream
  */
 function switchLatest(stream) {
-	return new Stream(new Switch(stream.source));
-}
+	var upstream = new Stream(new MulticastSource(stream.source));
 
-function Switch(source) {
-	this.source = source;
-}
+	return concurrentMergeMap(untilNext, 1, upstream);
 
-Switch.prototype.run = function(sink, scheduler) {
-	var switchSink = new SwitchSink(sink, scheduler);
-	return new ChainDisposable(switchSink, this.source.run(switchSink, scheduler));
-};
-
-function SwitchSink(sink, scheduler) {
-	this.sink = sink;
-	this.scheduler = scheduler;
-	this.current = null;
-	this.ended = false;
-}
-
-SwitchSink.prototype.event = function(t, stream) {
-	this._disposeCurrent(t); // TODO: capture the result of this dispose
-	this.current = new Segment(t, Infinity, this, this.sink);
-	this.current.disposable = stream.source.run(this.current, this.scheduler);
-};
-
-SwitchSink.prototype.end = function(t, x) {
-	this.ended = true;
-	this._checkEnd(t, x);
-};
-
-SwitchSink.prototype.error = function(t, e) {
-	this.ended = true;
-	this.sink.error(t, e);
-};
-
-SwitchSink.prototype.dispose = function() {
-	return this._disposeCurrent(0);
-};
-
-SwitchSink.prototype._disposeCurrent = function(t) {
-	if(this.current !== null) {
-		return this.current._dispose(t);
+	function untilNext(s) {
+		return until(upstream, s);
 	}
-};
-
-SwitchSink.prototype._disposeInner = function(t, inner) {
-	inner._dispose(t); // TODO: capture the result of this dispose
-	if(inner === this.current) {
-		this.current = null;
-	}
-};
-
-SwitchSink.prototype._checkEnd = function(t, x) {
-	if(this.ended && this.current === null) {
-		this.sink.end(t, x);
-	}
-};
-
-SwitchSink.prototype._endInner = function(t, x, inner) {
-	this._disposeInner(t, inner);
-	this._checkEnd(t, x);
-};
-
-SwitchSink.prototype._errorInner = function(t, e, inner) {
-	this._disposeInner(t, inner);
-	this.sink.error(t, e);
-};
-
-function Segment(min, max, outer, sink) {
-	this.min = min;
-	this.max = max;
-	this.outer = outer;
-	this.sink = sink;
-	this.disposable = new EmptyDisposable();
 }
-
-Segment.prototype.event = function(t, x) {
-	if(t < this.max) {
-		this.sink.event(Math.max(t, this.min), x);
-	}
-};
-
-Segment.prototype.end = function(t, x) {
-	this.outer._endInner(Math.max(t, this.min), x, this);
-};
-
-Segment.prototype.error = function(t, e) {
-	this.outer._errorInner(Math.max(t, this.min), e, this);
-};
-
-Segment.prototype._dispose = function(t) {
-	this.max = t;
-	return this.disposable.dispose();
-};


### PR DESCRIPTION
This reuses `until` and `concurrentMergeMap` to achieve the same behavior with much less code.