### PR TITLE
Fix debounce final event handling

### DIFF
--- a/lib/combinator/limit.js
+++ b/lib/combinator/limit.js
@@ -72,6 +72,7 @@ function DebounceSink(dt, source, sink, scheduler) {
 	this.dt = dt;
 	this.sink = sink;
 	this.scheduler = scheduler;
+	this.value = void 0;
 	this.timer = null;
 
 	var sourceDisposable = source.run(this, scheduler);
@@ -80,11 +81,15 @@ function DebounceSink(dt, source, sink, scheduler) {
 
 DebounceSink.prototype.event = function(t, x) {
 	this._clearTimer();
+	this.value = x;
 	this.timer = this.scheduler.delay(this.dt, PropagateTask.event(x, this.sink));
 };
 
 DebounceSink.prototype.end = function(t, x) {
-	this._clearTimer();
+	if(this._clearTimer()) {
+		this.sink.event(t, this.value);
+		this.value = void 0;
+	}
 	this.sink.end(t, x);
 };
 
@@ -98,8 +103,10 @@ DebounceSink.prototype.dispose = function() {
 };
 
 DebounceSink.prototype._clearTimer = function() {
-	if(this.timer !== null) {
-		this.timer.cancel();
-		this.timer = null;
+	if(this.timer === null) {
+		return false;
 	}
+	this.timer.cancel();
+	this.timer = null;
+	return true;
 };

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -3,15 +3,18 @@ var expect = require('buster').expect;
 
 var limit = require('../lib/combinator/limit');
 var periodic = require('../lib/source/periodic').periodic;
+var create = require('../lib/source/create').create;
 var delay = require('../lib/combinator/delay').delay;
 var transform = require('../lib/combinator/transform');
 var merge = require('../lib/combinator/merge').merge;
-var flatMap = require('../lib/combinator/flatMap').flatMap;
 var take = require('../lib/combinator/slice').take;
 var reduce = require('../lib/combinator/accumulate').reduce;
 var observe = require('../lib/combinator/observe').observe;
 var fromArray = require('../lib/source/fromArray').fromArray;
-var empty = require('../lib/source/core').empty;
+var core = require('../lib/source/core');
+
+var empty = core.empty;
+var streamOf = core.of;
 
 var map = transform.map;
 var constant = transform.constant;
@@ -24,28 +27,43 @@ var other = { value: 'other' };
 describe('debounce', function() {
 	describe('when events always occur less frequently than debounce period', function() {
 		it('should be identity', function() {
-			var a = [0,1,2,3,4];
-			var expected = a.slice(0, -1);
-
-			var s = take(5, map(function() {
-				return a.shift();
-			}, periodic(20)));
+			var s = take(5, periodic(20, sentinel));
 
 			var debounced = limit.debounce(10, s);
 
-			return reduce(function(a, x) {
-				return a.concat(x);
-			}, [], debounced)
-				.then(function(array) {
-					expect(array).toEqual(expected);
+			return reduce(function(count) {
+				return count + 1;
+			}, 0, debounced)
+				.then(function(count) {
+					expect(count).toBe(5);
 				});
 		});
 	});
 
 	describe('when events always occur more frequently than debounce period', function() {
-		it('should be empty', function() {
+		it('should be empty when source is empty', function() {
+			var s = limit.debounce(10, empty());
+			return reduce(function(x) {
+				return x + 1;
+			}, 0, s)
+				.then(function(x) {
+					expect(x).toBe(0);
+				});
+		});
+
+		it('should be identity when source is singleton', function() {
+			var s = limit.debounce(10, streamOf(sentinel));
+			return reduce(function(a, x) {
+				return a.concat(x);
+			}, [], s)
+				.then(function(x) {
+					expect(x).toEqual([sentinel]);
+				});
+		});
+
+		it('should contain last event when source has many', function() {
 			var a = [0,1,2,3,4,5,6,7,8,9];
-			var expected = [];
+			var expected = a.slice(a.length - 1);
 
 			var s = take(10, map(function() {
 				return a.shift();
@@ -63,17 +81,29 @@ describe('debounce', function() {
 	});
 
 	it('should allow events that occur less frequently than debounce period', function() {
+		var s = create(function(add, end) {
+			setTimeout(addOther,     0);
+			setTimeout(addOther,    10);
+			setTimeout(addSentinel, 20);
 
-		var s1 = constant(1, periodic(30));
-		var s2 = delay(10, constant(0, periodic(30)));
+			setTimeout(addOther,    50);
+			setTimeout(addOther,    60);
+			setTimeout(addSentinel, 70);
 
-		// s: 10-10-10-10->
+			setTimeout(end, 80);
 
-		var s = take(5, limit.debounce(15, merge(s1, s2)));
+			function addSentinel() {
+				add(sentinel);
+			}
+
+			function addOther() {
+				add(other);
+			}
+		});
 
 		return observe(function(x) {
-			expect(x).toBe(0);
-		}, s);
+			expect(x).toBe(sentinel);
+		}, limit.debounce(15, s));
 	});
 });
 

--- a/test/timeslice-test.js
+++ b/test/timeslice-test.js
@@ -22,7 +22,7 @@ var other = { value: 'other' };
 describe('during', function() {
 	it('should contain events at or later than min and earlier than max', function() {
 		var stream = periodic(10);
-		var timespan = delay(30, streamOf(delay(41, streamOf())));
+		var timespan = delay(30, streamOf(delay(45, streamOf())));
 
 		return reduce(function(count) {
 			return count + 1;
@@ -35,13 +35,10 @@ describe('during', function() {
 	it('should dispose source stream', function() {
 		var dispose = this.spy();
 		var stream = new Stream(FakeDisposeSource.from(dispose, periodic(10)));
-		var timespan = delay(30, streamOf(delay(41, streamOf())));
+		var timespan = delay(30, streamOf(delay(45, streamOf())));
 
-		return reduce(function(count) {
-			return count + 1;
-		}, 0, timeslice.during(timespan, stream))
-			.then(function(count) {
-				expect(count).toBe(5);
+		return drain(timeslice.during(timespan, stream))
+			.then(function() {
 				expect(dispose).toHaveBeenCalledOnce();
 			});
 
@@ -67,7 +64,7 @@ describe('during', function() {
 describe('takeUntil', function() {
 	it('should only contain events earlier than signal', function() {
 		var stream = periodic(10);
-		var signal = delay(30, streamOf());
+		var signal = delay(25, streamOf());
 
 		return reduce(function(count) {
 			return count + 1;
@@ -82,11 +79,8 @@ describe('takeUntil', function() {
 		var stream = new Stream(FakeDisposeSource.from(dispose, periodic(10)));
 		var signal = delay(30, streamOf());
 
-		return reduce(function(count) {
-			return count + 1;
-		}, 0, timeslice.takeUntil(signal, stream))
-			.then(function(count) {
-				expect(count).toBe(3);
+		return drain(timeslice.takeUntil(signal, stream))
+			.then(function() {
 				expect(dispose).toHaveBeenCalledOnce();
 			});
 
@@ -107,7 +101,7 @@ describe('takeUntil', function() {
 	it('should dispose signal', function() {
 		var dispose = this.spy();
 		var stream = periodic(10);
-		var signal = new Stream(FakeDisposeSource.from(dispose, delay(30, streamOf())));
+		var signal = new Stream(FakeDisposeSource.from(dispose, delay(25, streamOf())));
 
 		return reduce(function(count) {
 			return count + 1;
@@ -145,7 +139,7 @@ describe('skipUntil', function() {
 	it('should dispose signal', function() {
 		var dispose = this.spy();
 		var stream = take(10, periodic(10));
-		var signal = new Stream(FakeDisposeSource.from(dispose, delay(30, streamOf())));
+		var signal = new Stream(FakeDisposeSource.from(dispose, delay(25, streamOf())));
 
 		return reduce(function(count) {
 			return count + 1;


### PR DESCRIPTION
When debounce ends, if there is a pending event, it is now emitted before ending the stream.  This commit also improves the reliability of several time-based tests, including debounce tests.