### PR TITLE
Deprecate lift

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1146,6 +1146,8 @@ resultStream.observe(function(z) {
 
 ####`most.lift(f) -> function`
 
+**DEPRECATED**
+
 Lifts a function to act on streams.  Lifting returns a function that accepts streams as arguments, and returns a stream as a result.
 
 One way to think of lifting is that it takes a function that operates on "normal" values, like two strings, and creates a function that operates on "time-varying" values--on the "current value" of two `<input>` elements, for example.

--- a/lib/combinator/lift.js
+++ b/lib/combinator/lift.js
@@ -10,6 +10,7 @@ var liftedSuffix = '_most$Stream$lifted';
 exports.lift = lift;
 
 /**
+ * @deprecated
  * Lift a function to operate on streams.  For example:
  * lift(function(x:number, y:number):number) -> function(xs:Stream, ys:Stream):Stream
  * @param {function} f function to be lifted


### PR DESCRIPTION
We'll need to add a section on using the curried forms of `map` and `combine` instead of `lift`.