### PR TITLE
Add multicast combinator

### DIFF
--- a/lib/combinator/multicast.js
+++ b/lib/combinator/multicast.js
@@ -1,6 +1,7 @@
 /** @license MIT License (c) copyright 2010-2015 original author or authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
+/** @contributor Maciej Ligenza */
 
 var Stream = require('../Stream');
 var MulticastSource = require('../source/MulticastSource');
@@ -9,7 +10,7 @@ exports.multicast = multicast;
 
 /**
  * Transform the stream into multicast stream.  That means that many subscribers
- * to the stream will not cause multiple invokations of the internal machinery.
+ * to the stream will not cause multiple invocations of the internal machinery.
  * @param {Stream} stream to be transformed.
  * @returns {Stream} new stream which will multicast events to all observers.
  */

--- a/lib/combinator/multicast.js
+++ b/lib/combinator/multicast.js
@@ -1,0 +1,18 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+var Stream = require('../Stream');
+var MulticastSource = require('../source/MulticastSource');
+
+exports.multicast = multicast;
+
+/**
+ * Transform the stream into multicast stream.  That means that many subscribers
+ * to the stream will not cause multiple invokations of the internal machinery.
+ * @param {Stream} stream to be transformed.
+ * @returns {Stream} new stream which will multicast events to all observers.
+ */
+function multicast(stream) {
+	return new Stream(new MulticastSource(stream.source));
+}

--- a/most.js
+++ b/most.js
@@ -649,3 +649,20 @@ exports.throwError   = errors.throwError;
 Stream.prototype.flatMapError = function(f) {
 	return errors.flatMapError(f, this);
 };
+
+//-----------------------------------------------------------------------
+// Changing behavior
+
+var multicast = require('./lib/combinator/multicast').multicast;
+
+
+exports.multicast = multicast;
+
+/**
+ * Transform the stream into multicast stream.  That means that many subscribers
+ * to the stream will not cause multiple invokations of the internal machinery.
+ * @returns {Stream} new stream which will multicast events to all observers.
+ */
+Stream.prototype.multicast = function() {
+	return multicast(this);
+};

--- a/most.js
+++ b/most.js
@@ -633,7 +633,6 @@ Stream.prototype.await = function() {
 
 var errors = require('./lib/combinator/errors');
 
-
 exports.flatMapError = errors.flatMapError;
 exports.throwError   = errors.throwError;
 
@@ -651,16 +650,15 @@ Stream.prototype.flatMapError = function(f) {
 };
 
 //-----------------------------------------------------------------------
-// Changing behavior
+// Multicasting
 
 var multicast = require('./lib/combinator/multicast').multicast;
-
 
 exports.multicast = multicast;
 
 /**
  * Transform the stream into multicast stream.  That means that many subscribers
- * to the stream will not cause multiple invokations of the internal machinery.
+ * to the stream will not cause multiple invocations of the internal machinery.
  * @returns {Stream} new stream which will multicast events to all observers.
  */
 Stream.prototype.multicast = function() {

--- a/test/combinator/multicast-test.js
+++ b/test/combinator/multicast-test.js
@@ -1,0 +1,51 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var streamOf = require('../../lib/source/core').of;
+var map = require('../../lib/combinator/transform').map;
+var observe = require('../../lib/combinator/observe').observe;
+var multicast = require('../../lib/combinator/multicast').multicast;
+var all = require('../../lib/Promise').all;
+
+var sentinel = { value: 'sentinel' };
+var other = { value: 'other' };
+
+describe('multicast', function() {
+
+	it('two observers attached to mapping stream cause mapper function to be called twice', function() {
+		var mapperSpy = this.spy();
+		var observer1Spy = this.spy();
+		var observer2Spy = this.spy();
+
+    var s = streamOf(sentinel);
+    var mapped = map(mapperSpy, s);
+    
+    var o1 = observe(observer1Spy, mapped);
+    var o2 = observe(observer2Spy, mapped);
+
+		return all([o1,o2]).then(function(a) {
+      expect(mapperSpy).toHaveBeenCalledTwice();
+      expect(observer1Spy).toHaveBeenCalledOnce();
+      expect(observer2Spy).toHaveBeenCalledOnce();
+		});
+	});
+
+	it('two observers attached to multicasted mapping stream cause mapper function to be called once', function() {
+		var mapperSpy = this.spy();
+		var observer1Spy = this.spy();
+		var observer2Spy = this.spy();
+
+    var s = streamOf(sentinel);
+    var mapped = map(mapperSpy, s);
+    var multicasted = multicast(mapped);
+    
+    var o1 = observe(observer1Spy, multicasted);
+    var o2 = observe(observer2Spy, multicasted);
+
+		return all([o1,o2]).then(function(a) {
+      expect(mapperSpy).toHaveBeenCalledOnce();
+      expect(observer1Spy).toHaveBeenCalledOnce();
+      expect(observer2Spy).toHaveBeenCalledOnce();
+		});
+	});
+});


### PR DESCRIPTION
This adds stream.multicast() that converts a stream into a multicast stream (as one of the solutions to #139).

This will probably be superseded by internal changes that will handle multicasting in a more user-friendly way. Maybe it should be denoted as deprecated from the very beginning? ;)

No documentation (yet). No tests as it feels like too simple to break/test.

I've added new combinator even though it is extremely simple (could be done in most.js main file). Any hints if this is a good approach?