### PR TITLE
Add timeslot ordering

### DIFF
--- a/lib/combinator/combine.js
+++ b/lib/combinator/combine.js
@@ -5,8 +5,8 @@
 var Stream = require('../Stream');
 var transform = require('./transform');
 var core = require('../source/core');
-var Pipe = require('../sink/Pipe');
 var IndexSink = require('../sink/IndexSink');
+var PropagateTask = require('../scheduler/PropagateTask');
 var CompoundDisposable = require('../disposable/CompoundDisposable');
 var base = require('../base');
 var invoke = require('../invoke');
@@ -57,7 +57,7 @@ Combine.prototype.run = function(sink, scheduler) {
 	var disposables = new Array(l);
 	var sinks = new Array(l);
 
-	var combineSink = new CombineSink(this.f, sinks, sink);
+	var combineSink = new CombineSink(this.f, sinks, scheduler, sink);
 
 	for(var indexSink, i=0; i<l; ++i) {
 		indexSink = sinks[i] = new IndexSink(i, combineSink);
@@ -67,29 +67,49 @@ Combine.prototype.run = function(sink, scheduler) {
 	return new CompoundDisposable(disposables);
 };
 
-function CombineSink(f, sinks, sink) {
+function CombineSink(f, sinks, scheduler, sink) {
 	this.f = f;
 	this.sinks = sinks;
+	this.scheduler = scheduler;
 	this.sink = sink;
-	this.ready = false;
+	this.active = false;
 	this.activeCount = sinks.length;
+	this.time = -Infinity;
 }
 
 CombineSink.prototype.event = function(t /*, indexSink */) {
-	if(!this.ready) {
-		this.ready = this.sinks.every(hasValue);
+	if(!this.active) {
+		this.active = this.sinks.every(hasValue);
 	}
 
-	if(this.ready) {
-		// TODO: Maybe cache values in their own array once this.ready
-		this.sink.event(t, invoke(this.f, map(getValue, this.sinks)));
+	if(this.active && t > this.time) {
+		this.time = t;
+		this.task = this.scheduler.at(t, new CombineTask(this.f, this.sinks, this.sink), 1);
 	}
 };
 
 CombineSink.prototype.end = function(t, indexedValue) {
 	if(--this.activeCount === 0) {
-		this.sink.end(t, indexedValue.value);
+		this.scheduler.at(t, PropagateTask.end(indexedValue.value, this.sink), 1);
 	}
 };
 
-CombineSink.prototype.error = Pipe.prototype.error;
+CombineSink.prototype.error = function(t, e) {
+	this.scheduler.at(t, PropagateTask.error(e, this.sink), 1);
+};
+
+function CombineTask(f, sinks, sink) {
+	this.f = f;
+	this.sinks = sinks;
+	this.sink = sink;
+}
+
+CombineTask.prototype.run = function(t) {
+	this.sink.event(t, invoke(this.f, map(getValue, this.sinks)));
+};
+
+CombineTask.prototype.error = function(t, e) {
+	this.sink.error(t, e);
+};
+
+CombineTask.prototype.dispose = base.noop;

--- a/lib/scheduler/ScheduledTask.js
+++ b/lib/scheduler/ScheduledTask.js
@@ -1,0 +1,27 @@
+/** @license MIT License (c) copyright 2010-2015 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+module.exports = ScheduledTask;
+
+function ScheduledTask(time, period, priority, task, scheduler) {
+	this.time = time;
+	this.period = period;
+	this.priority = priority;
+	this.task = task;
+	this.scheduler = scheduler;
+	this.active = true;
+}
+
+ScheduledTask.prototype.run = function() {
+	return this.task.run(this.time);
+};
+
+ScheduledTask.prototype.error = function(e) {
+	return this.task.error(this.time, e);
+};
+
+ScheduledTask.prototype.cancel = function() {
+	this.scheduler.cancel(this);
+	return this.task.dispose();
+};

--- a/lib/scheduler/Scheduler.js
+++ b/lib/scheduler/Scheduler.js
@@ -2,45 +2,18 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var base = require('./../base');
+var base = require('../base');
+var ScheduledTask = require('./ScheduledTask');
 
 var findIndex = base.findIndex;
 
 module.exports = Scheduler;
 
-function ScheduledTask(delay, period, task, scheduler) {
-	this.time = delay;
-	this.period = period;
-	this.task = task;
-	this.scheduler = scheduler;
-	this.active = true;
-}
-
-ScheduledTask.prototype.run = function() {
-	return this.task.run(this.time);
-};
-
-ScheduledTask.prototype.error = function(e) {
-	return this.task.error(this.time, e);
-};
-
-ScheduledTask.prototype.cancel = function() {
-	this.scheduler.cancel(this);
-	return this.task.dispose();
-};
-
-function runTask(task) {
-	try {
-		return task.run();
-	} catch(e) {
-		return task.error(e);
-	}
-}
-
 function Scheduler(setTimer, clearTimer, now) {
 	this.now = now;
 	this._setTimer = setTimer;
 	this._clearTimer = clearTimer;
+	this.defaultPriority = 0;
 
 	this._timer = null;
 	this._nextArrival = 0;
@@ -52,21 +25,33 @@ function Scheduler(setTimer, clearTimer, now) {
 	};
 }
 
-Scheduler.prototype.asap = function(task) {
-	return this.schedule(0, -1, task);
+Scheduler.prototype.at = function(time, task, priority) {
+	return this.schedule(this.now(), time, -1, task, priority);
 };
 
-Scheduler.prototype.delay = function(delay, task) {
-	return this.schedule(delay, -1, task);
+Scheduler.prototype.asap = function(task, priority) {
+	return this.relative(0, -1, task, priority);
 };
 
-Scheduler.prototype.periodic = function(period, task) {
-	return this.schedule(0, period, task);
+Scheduler.prototype.delay = function(delay, task, priority) {
+	return this.relative(delay, -1, task, priority);
 };
 
-Scheduler.prototype.schedule = function(delay, period, task) {
+Scheduler.prototype.periodic = function(period, task, priority) {
+	return this.relative(0, period, task, priority);
+};
+
+Scheduler.prototype.relative = function(delay, period, task, priority) {
 	var now = this.now();
-    var st = new ScheduledTask(now + Math.max(0, delay), period, task, this);
+	return this.schedule(now, now + Math.max(0, delay), period, task, priority);
+};
+
+Scheduler.prototype.schedule = function(now, time, period, task, priority) {
+	if(typeof priority !== 'number') {
+		priority = this.defaultPriority;
+	}
+
+    var st = new ScheduledTask(time, period, priority, task, this);
 
 	insertByTime(st, this._tasks);
 	this._scheduleNextRun(now);
@@ -176,33 +161,59 @@ function insertByTime(task, tasks) {
 }
 
 function findInsertion(task, tasks) {
-	var i = binarySearch(task, tasks);
+	var i = binarySearch(byTimeAndPriority, task, tasks);
 	var l = tasks.length;
 	var t = task.time;
+	var p = task.priority;
 
-	while(i<l && t === tasks[i].time) {
+	while(i<l && t === tasks[i].time && p === tasks[i].priority) {
 		++i;
 	}
 
 	return i;
 }
 
-function binarySearch(x, sortedArray) {
+function binarySearch(compare, x, sortedArray) {
 	var lo = 0;
 	var hi = sortedArray.length;
 	var mid, y;
+	var c;
 
 	while (lo < hi) {
 		mid = Math.floor((lo + hi) / 2);
 		y = sortedArray[mid];
 
-		if (x.time === y.time) {
+		c = compare(x, y);
+
+		if (c === 0) {
 			return mid;
-		} else if (x.time < y.time) {
+		} else if (c < 0) {
 			hi = mid;
 		} else {
 			lo = mid + 1;
 		}
 	}
 	return hi;
+}
+
+function byTimeAndPriority(t1, t2) {
+	var t1t = t1.time;
+	var t2t = t2.time;
+
+	var t1p = t1.priority;
+	var t2p = t2.priority;
+
+	return t1t < t2t ? -1
+		: t1t > t2t ? 1
+		: t1p < t2p ? -1
+		: t1p > t2p ? 1
+		: 0;
+}
+
+function runTask(task) {
+	try {
+		return task.run();
+	} catch(e) {
+		return task.error(e);
+	}
 }


### PR DESCRIPTION
Tasks can be ordered even within a single timeslot.  That allows actions to be taken "later" in the same timeslot.  For example, combine can behave predictably in the face of simultaneous events:

```js
let x = most.whatever();

// combine x with itself
// Each time an event occurs in x, only *one* event should occur in x2
let x2 = most.combine((xa, xb) => xa + xb, x, x);
```