### PR TITLE
Improve drag'n'drop example

### DIFF
--- a/examples/drag-n-drop/index.html
+++ b/examples/drag-n-drop/index.html
@@ -2,11 +2,19 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Document</title>
+    <title>Drag'n'Drop Demo for Most.js</title>
     <style>
+        html, body {
+          height: 100%;
+          margin: 0;
+        }
         body {
           font-size: 1em;
-          font-family: 'Helvetica Nueue', Helvetica, sans-serif;
+          font-family: 'Helvetica Neue', Helvetica, sans-serif;
+        }
+        .dragging-area {
+            width: 100%;
+            height: 100%;
         }
         .box {
           -webkit-transition: box-shadow 100ms ease;
@@ -41,6 +49,8 @@
     <script src="bower_components/rave/rave.js"></script>
 </head>
 <body>
-    <div class="box draggable"><span class="rest">Drag</span><span class="drag">Drop</span> me, baby!</div>
+    <div class="dragging-area">
+        <div class="box draggable"><span class="rest">Drag</span><span class="drag">Drop</span> me, baby!</div>
+    </div>
 </body>
 </html>

--- a/examples/drag-n-drop/main.js
+++ b/examples/drag-n-drop/main.js
@@ -11,29 +11,39 @@ var most = require('most');
 var DROP = 0, GRAB = 1, DRAG = 2;
 
 module.exports = function() {
+	// The area where we want to do the dragging
+	var area = document.querySelector('.dragging-area');
 	// The thing we want to make draggable
 	var draggable = document.querySelector('.draggable');
+	var dragOffset = {};
 
-	// A higher-order stream (stream whose events are themselves streams)
+	// A higher-order stream (stream whose items are themselves streams)
 	// A mousedown DOM event generates a stream event which is
-	// a stream of 1 GRAB followed by DRAGS (ie mousemoves).
+	// a stream of 1 GRAB followed by DRAGs (ie mousemoves).
 	var drag = most.fromEvent('mousedown', draggable)
 		.map(function(e) {
-			return most.fromEvent('mousemove', e.target)
+			// On Firefox, avoid the dragging to select text
+			e.preventDefault();
+
+			// Memorize click position within the box
+			dragOffset.dx = e.clientX - draggable.offsetLeft;
+			dragOffset.dy = e.clientY - draggable.offsetTop;
+
+			return most.fromEvent('mousemove', area)
 				.map(function(e) {
-					return eventToDragInfo(DRAG, e);
+					return eventToDragInfo(DRAG, draggable, e);
 				})
-				.startWith(eventToDragInfo(GRAB, e));
+				.startWith(eventToDragInfo(GRAB, draggable, e));
 		});
 
 	// A mouseup DOM event generates a stream event which is a
-	// stream containing a DROP
-	var drop = most.fromEvent('mouseup', draggable)
+	// stream containing a DROP.
+	var drop = most.fromEvent('mouseup', area)
 		.map(function(e) {
-			return most.of(eventToDragInfo(DROP, e));
+			return most.of(eventToDragInfo(DROP, draggable, e));
 		});
 
-	// Merge the drag and drop streams
+	// Merge the drag and drop streams.
 	// Then use switch() to ensure that the resulting stream behaves
 	// like the drag stream until an event occurs on the drop stream.  Then
 	// it will behave like the drop stream until the drag stream starts
@@ -42,27 +52,25 @@ module.exports = function() {
 	// dropped behavior.
 	most.merge(drag, drop)
 		.switch()
-		.reduce(handleDrag, offset(draggable));
+		.reduce(handleDrag, dragOffset);
 };
 
-function offset(el) {
-	return { dx: Math.floor(el.offsetWidth / 2), dy: Math.floor(el.offsetHeight / 2) };
-}
-
-function eventToDragInfo(action, e) {
-	return { action: action, target: e.target, x: e.clientX, y: e.clientY };
+function eventToDragInfo(action, target, e) {
+	return { action: action, target: target, x: e.clientX, y: e.clientY };
 }
 
 function handleDrag(offset, dd) {
 	var el = dd.target;
+	console.log(dd);
 
-	if(dd.action === GRAB) {
+	if (dd.action === GRAB) {
 		el.classList.add('dragging');
 		return offset;
 	}
 
-	if(dd.action === DROP) {
+	if (dd.action === DROP) {
 		el.classList.remove('dragging');
+		return offset;
 	}
 
 	var els = dd.target.style;


### PR DESCRIPTION
- Mouse move and up events are on the whole page, avoiding loosing the
box when moving fast.
- Memorize the mouse down location, to avoid centering box on mouse.
- Prevent default mouse down event to avoid selecting text in box in FF.