### PR TITLE
api doc fixes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -136,7 +136,7 @@ stream.forEach(console.log.bind(console)); // logs hello
 ```js
 // Use `just` for easy ES6 import
 import { just } from 'most';
-let stream = most.just('hello');
+let stream = just('hello');
 stream.observe(x => console.log(x));
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -867,8 +867,8 @@ stream.takeWhile(even): -2-4-|
 
 ### skipWhile
 
-####`stream.takeWhile(predicate) -> Stream`
-####`most.takeWhile(predicate, stream) -> Stream`
+####`stream.skipWhile(predicate) -> Stream`
+####`most.skipWhile(predicate, stream) -> Stream`
 
 Create a new stream containing all events after `predicate` returns false.
 


### PR DESCRIPTION
I'm guessing you mean `just` instead of `most.just` :-)

Edit: found another copy/paste regression in `skipWhile`