### PR TITLE
Make scan preserve end value

### DIFF
--- a/lib/combinator/accumulate.js
+++ b/lib/combinator/accumulate.js
@@ -51,10 +51,7 @@ ScanSink.prototype.event = function(t, x) {
 };
 
 ScanSink.prototype.error = Pipe.prototype.error;
-
-ScanSink.prototype.end = function(t) {
-	this.sink.end(t, this.value);
-};
+ScanSink.prototype.end = Pipe.prototype.end;
 
 /**
  * Reduce a stream to produce a single result.  Note that reducing an infinite

--- a/test/accumulate-test.js
+++ b/test/accumulate-test.js
@@ -7,6 +7,7 @@ var throwError = require('../lib/combinator/errors').throwError;
 var observe = require('../lib/combinator/observe').observe;
 var drain = require('../lib/combinator/observe').drain;
 var fromArray = require('../lib/source/fromArray').fromArray;
+var create = require('../lib/source/create').create;
 var core = require('../lib/source/core');
 
 var scan = accumulate.scan;
@@ -33,6 +34,24 @@ describe('scan', function() {
 			++i;
 			expect(s).toEqual(items.slice(0, i));
 		}, stream);
+	});
+
+	it('should preserve end value', function() {
+		var expectedEndValue = {};
+		var stream = create(function(add, end) {
+			add(1);
+			add(2);
+			end(expectedEndValue);
+		});
+
+		var s = scan(function(a, x) {
+			expect(x).notToBe(expectedEndValue);
+			return x;
+		}, 0, stream);
+
+		return drain(s).then(function(endValue) {
+			expect(endValue).toBe(expectedEndValue);
+		});
 	});
 
 	it('should dispose', function() {


### PR DESCRIPTION
Scan was clobbering the stream end value by substituting the last value in the stream for the end value.  This makes scan propagate the end value.  As a bonus, it also simplifies the code slightly.

Fix #162 