### PR TITLE
remove unnecessary Function#call in ThrottleSink#end

### DIFF
--- a/lib/combinator/limit.js
+++ b/lib/combinator/limit.js
@@ -42,9 +42,7 @@ ThrottleSink.prototype.event = function(t, x) {
 	}
 };
 
-ThrottleSink.prototype.end   = function(t, e) {
-	return Sink.prototype.end.call(this, t, e);
-};
+ThrottleSink.prototype.end   = Sink.prototype.end;
 
 ThrottleSink.prototype.error = Sink.prototype.error;
 


### PR DESCRIPTION
Previously of c36db75fb8ddca310014c7e353e3970ba5f720d8 it was also `ThrottleSink.prototype.end   = Sink.prototype.end;`. Was there a reason why this has been changed?