### PR TITLE
Fix spelling error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ bower install --save most`
 <script src="most/dist/most.js"></script>
 ```
 
-## Iteroperability
+## Interoperability
 
 <a href="http://promises-aplus.github.com/promises-spec"><img width="82" height="82" alt="Promises/A+" src="http://promises-aplus.github.com/promises-spec/assets/logo-small.png"></a>
 <a href="https://github.com/fantasyland/fantasy-land"><img width="82" height="82" alt="Fantasy Land" src="https://raw.github.com/puffnfresh/fantasy-land/master/logo.png"></a>


### PR DESCRIPTION
`Iteroperability` → `Interoperability`