### PR TITLE
Update performance tests

### DIFF
--- a/test/perf/concatMap.js
+++ b/test/perf/concatMap.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -44,11 +45,14 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).concatMap(most.from).reduce(sum, 0));
 	}, options)
-	.add('rx', function(deferred) {
+	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).concatMap(rx.Observable.fromArray).reduce(sum, 0));
 	}, options)
+  .add('rx 5', function(deffered) {
+    runners.runRx5(deffered, rxjs.Observable.fromArray(a).concatMap(function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).reduce(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).flatMapConcat(bacon.fromArray).reduce(0, sum));

--- a/test/perf/concatMap.js
+++ b/test/perf/concatMap.js
@@ -52,7 +52,7 @@ suite
     runners.runRx5(deffered, rxjs.Observable.fromArray(a).concatMap(function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).flatMapConcat(bacon.fromArray).reduce(0, sum));

--- a/test/perf/concatMap.js
+++ b/test/perf/concatMap.js
@@ -48,9 +48,9 @@ suite
 	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).concatMap(rx.Observable.fromArray).reduce(sum, 0));
 	}, options)
-  .add('rx 5', function(deffered) {
-    runners.runRx5(deffered, rxjs.Observable.fromArray(a).concatMap(function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
-  }, options)
+	.add('rx 5', function(deffered) {
+		runners.runRx5(deffered, rxjs.Observable.fromArray(a).concatMap(function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).flatMapConcat(kefirFromArray).scan(sum, 0).last());
 	}, options)

--- a/test/perf/filter-map-reduce.js
+++ b/test/perf/filter-map-reduce.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -29,11 +30,15 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).filter(even).map(add1).reduce(sum, 0));
 	}, options)
-	.add('rx', function(deferred) {
+	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
 	}, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred,
+      rxjs.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).filter(even).map(add1).reduce(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).filter(even).map(add1).scan(sum, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).filter(even).map(add1).reduce(0, sum));

--- a/test/perf/filter-map-reduce.js
+++ b/test/perf/filter-map-reduce.js
@@ -33,10 +33,10 @@ suite
 	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
 	}, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred,
-      rxjs.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
-  }, options)
+	.add('rx 5', function(deferred) {
+		runners.runRx5(deferred,
+			rxjs.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).filter(even).map(add1).scan(sum, 0).last());
 	}, options)

--- a/test/perf/filter-map-reduce.js
+++ b/test/perf/filter-map-reduce.js
@@ -38,7 +38,7 @@ suite
       rxjs.Observable.fromArray(a).filter(even).map(add1).reduce(sum, 0));
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).filter(even).map(add1).scan(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).filter(even).map(add1).scan(sum, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).filter(even).map(add1).reduce(0, sum));

--- a/test/perf/flatMap.js
+++ b/test/perf/flatMap.js
@@ -54,7 +54,7 @@ suite
         function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).flatMap(bacon.fromArray).reduce(0, sum));

--- a/test/perf/flatMap.js
+++ b/test/perf/flatMap.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -44,11 +45,16 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).flatMap(most.from).reduce(sum, 0));
 	}, options)
-	.add('rx', function(deferred) {
+	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).flatMap(rx.Observable.fromArray).reduce(sum, 0));
 	}, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred,
+      rxjs.Observable.fromArray(a).flatMap(
+        function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).reduce(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).flatMap(bacon.fromArray).reduce(0, sum));

--- a/test/perf/flatMap.js
+++ b/test/perf/flatMap.js
@@ -48,11 +48,11 @@ suite
 	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).flatMap(rx.Observable.fromArray).reduce(sum, 0));
 	}, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred,
-      rxjs.Observable.fromArray(a).flatMap(
-        function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
-  }, options)
+	.add('rx 5', function(deferred) {
+		runners.runRx5(deferred,
+			rxjs.Observable.fromArray(a).flatMap(
+				function(x) {return rxjs.Observable.fromArray(x)}).reduce(sum, 0))
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).flatMap(kefirFromArray).scan(sum, 0).last());
 	}, options)

--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -4,12 +4,22 @@
   "description": "Perf tests for most.js",
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
+  "scripts": {
+    "concatMap": "node ./concatMap.js",
+    "filter-map-reduce": "node ./filter-map-reduce",
+    "flatMap": "node ./flatMap.js",
+    "scan": "node ./scan.js",
+    "skipRepeats": "node ./skipRepeats.js",
+    "zip": "node ./zip.js",
+    "start": "npm run concatMap && npm run filter-map-reduce && npm run flatMap && npm run scan && npm run skipRepeats && npm run zip"
+  },
   "dependencies": {
-    "baconjs": "^0.7.70",
-    "benchmark": "bestiejs/benchmark.js#master",
+    "@reactivex/rxjs": "^5.0.0-alpha.12",
+    "baconjs": "^0.7.82",
+    "benchmark": "github:bestiejs/benchmark.js#master",
     "highland": "^2.5.1",
-    "kefir": "^2.8.0",
-    "lodash": "^3.10.0",
-    "rx": "^3.1.0"
+    "kefir": "^3.1.0",
+    "lodash": "^3.10.1",
+    "rx": "^4.0.7"
   }
 }

--- a/test/perf/runners.js
+++ b/test/perf/runners.js
@@ -87,16 +87,16 @@ function runRx(deferred, rxStream) {
 }
 
 function runRx5(deferred, rxStream) {
-  rxStream.subscribe({
-    next: noop,
-    complete: function() {
-      deferred.resolve();
-    },
-    error: function(e) {
-      deferred.benchmark.emit({ type: 'error', error: e });
-      deferred.resolve(e);
-    }
-  });
+	rxStream.subscribe({
+		next: noop,
+		complete: function() {
+			deferred.resolve();
+		},
+		error: function(e) {
+			deferred.benchmark.emit({ type: 'error', error: e });
+			deferred.resolve(e);
+		}
+	});
 }
 
 function runKefir(deferred, kefirStream) {

--- a/test/perf/runners.js
+++ b/test/perf/runners.js
@@ -5,6 +5,7 @@ exports.runSuite       = runSuite;
 
 exports.runMost        = runMost;
 exports.runRx          = runRx;
+exports.runRx5         = runRx5;
 exports.runKefir       = runKefir;
 exports.kefirFromArray = kefirFromArray;
 exports.runBacon       = runBacon;
@@ -83,6 +84,19 @@ function runRx(deferred, rxStream) {
 			deferred.resolve(e);
 		}
 	});
+}
+
+function runRx5(deferred, rxStream) {
+  rxStream.subscribe({
+    next: noop,
+    complete: function() {
+      deferred.resolve();
+    },
+    error: function(e) {
+      deferred.benchmark.emit({ type: 'error', error: e });
+      deferred.resolve(e);
+    }
+  });
 }
 
 function runKefir(deferred, kefirStream) {

--- a/test/perf/scan.js
+++ b/test/perf/scan.js
@@ -37,7 +37,7 @@ suite
     runners.runRx5(deferred, rxjs.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0));
+		runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough));

--- a/test/perf/scan.js
+++ b/test/perf/scan.js
@@ -34,8 +34,8 @@ suite
 		runners.runRx(deferred, rx.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
 	}, options)
   .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
-  }, options)
+		runners.runRx5(deferred, rxjs.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0).last());
 	}, options)

--- a/test/perf/scan.js
+++ b/test/perf/scan.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs');
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -29,11 +30,14 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).scan(sum, 0).reduce(passthrough, 0));
 	}, options)
-	.add('rx', function(deferred) {
-		runners.runRx(deferred, rx.Observable.fromArray(a).scan(0, sum).reduce(passthrough, 0));
+	.add('rx 4', function(deferred) {
+		runners.runRx(deferred, rx.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
 	}, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred, rxjs.Observable.fromArray(a).scan(sum, 0).reduce(passthrough, 0));
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).reduce(passthrough, 0));
+		runners.runKefir(deferred, kefirFromArray(a).scan(sum, 0).scan(passthrough, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).scan(0, sum).reduce(0, passthrough));

--- a/test/perf/skipRepeats.js
+++ b/test/perf/skipRepeats.js
@@ -37,7 +37,7 @@ suite
     runners.runRx5(deferred, rxjs.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum));

--- a/test/perf/skipRepeats.js
+++ b/test/perf/skipRepeats.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs');
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -29,11 +30,14 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).skipRepeats().reduce(sum, 0));
 	}, options)
-	.add('rx', function(deferred) {
+	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
 	}, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred, rxjs.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().reduce(sum, 0));
+		runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.fromArray(a).skipDuplicates().reduce(0, sum));

--- a/test/perf/skipRepeats.js
+++ b/test/perf/skipRepeats.js
@@ -33,9 +33,9 @@ suite
 	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
 	}, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
-  }, options)
+	.add('rx 5', function(deferred) {
+		runners.runRx5(deferred, rxjs.Observable.fromArray(a).distinctUntilChanged().reduce(sum, 0));
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).skipDuplicates().scan(sum, 0).last());
 	}, options)

--- a/test/perf/zip.js
+++ b/test/perf/zip.js
@@ -40,7 +40,7 @@ suite
     runners.runRx5(deferred, rxjs.Observable.fromArray(a).zip(rxjs.Observable.fromArray(b), add).reduce(add, 0));
   }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0));
+		runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last());
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add));

--- a/test/perf/zip.js
+++ b/test/perf/zip.js
@@ -1,6 +1,7 @@
 var Benchmark = require('benchmark');
 var most = require('../../most');
 var rx = require('rx');
+var rxjs = require('@reactivex/rxjs');
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
@@ -32,11 +33,14 @@ suite
 	.add('most', function(deferred) {
 		runners.runMost(deferred, most.from(a).zip(add, most.from(b)).reduce(add, 0));
 	}, options)
-	.add('rx', function(deferred) {
+	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).zip(rx.Observable.fromArray(b), add).reduce(add, 0));
 	}, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred, rxjs.Observable.fromArray(a).zip(rxjs.Observable.fromArray(b), add).reduce(add, 0));
+  }, options)
 	.add('kefir', function(deferred) {
-		runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).reduce(add, 0));
+		runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0));
 	}, options)
 	.add('bacon', function(deferred) {
 		runners.runBacon(deferred, bacon.zipWith(add, bacon.fromArray(a), bacon.fromArray(b)).reduce(0, add));

--- a/test/perf/zip.js
+++ b/test/perf/zip.js
@@ -36,9 +36,9 @@ suite
 	.add('rx 4', function(deferred) {
 		runners.runRx(deferred, rx.Observable.fromArray(a).zip(rx.Observable.fromArray(b), add).reduce(add, 0));
 	}, options)
-  .add('rx 5', function(deferred) {
-    runners.runRx5(deferred, rxjs.Observable.fromArray(a).zip(rxjs.Observable.fromArray(b), add).reduce(add, 0));
-  }, options)
+	.add('rx 5', function(deferred) {
+		runners.runRx5(deferred, rxjs.Observable.fromArray(a).zip(rxjs.Observable.fromArray(b), add).reduce(add, 0));
+	}, options)
 	.add('kefir', function(deferred) {
 		runners.runKefir(deferred, kefirFromArray(a).zip(kefirFromArray(b), add).scan(add, 0).last());
 	}, options)


### PR DESCRIPTION
This updates all of the libraries to their most current versions as of (December 5 2015) and adds RxJS 5 to the tests as well.

Note that Kefir has removed their `reduce()` method and needed to be changed to `scan()`