### PR TITLE
Add mergeConcurrently to public API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -62,6 +62,7 @@ most.js API
 1. Combining higher order streams
 	* [switch](#switch)
 	* [join](#join)
+	* [mergeConcurrently](#mergeConcurrently)
 1. Awaiting promises
 	* [await](#await)
 1. Rate limiting streams
@@ -1252,6 +1253,27 @@ stream.join(): ---a---b--4c-5-d6->
 ```
 
 *TODO: Example*
+
+### mergeConcurrently
+
+####`stream.mergeConcurrently(concurrency) -> Stream`
+####`most.mergeConcurrently(concurrency, stream) -> Stream`
+
+Given a [higher-order stream](concepts.md#higher-order-streams), return a new stream that merges inner streams as they arrive *up to the specified concurrency*.  Once `concurrency` number of streams are being merged, newly arriving streams will be merged after an existing one ends.
+
+```
+s:                           --a--b--c--d--e-->
+t:                           --x------y|
+u:                           -1--2--3--4--5--6>
+stream:                      -s--t--u--------->
+stream.mergeConcurrently(2): --a------y4d-5e-6>
+```
+
+Note that `u` is only merged *after* `t` ends, due to the concurrency level of `2`.
+
+Note also that `stream.mergeConcurrently(Infinity)` is equivalent to [`stream.join()`](#join).
+
+To control concurrency, `mergeConcurrently` must maintain an internal queue of newly arrived streams.  If new streams arrive faster than the concurrency level allows them to be merged, the internal queue will grow infinitely.
 
 ## Awaiting promises
 

--- a/most.js
+++ b/most.js
@@ -289,6 +289,26 @@ Stream.prototype.concatMap = function(f) {
 };
 
 //-----------------------------------------------------------------------
+// Concurrent merging
+
+var mergeConcurrently = require('./lib/combinator/mergeConcurrently');
+
+exports.mergeConcurrently = mergeConcurrently.mergeConcurrently;
+
+/**
+ * Flatten a Stream<Stream<X>> to Stream<X> by merging inner
+ * streams to the outer, limiting the number of inner streams that may
+ * be active concurrently.
+ * @param {number} concurrency at most this many inner streams will be
+ *  allowed to be active concurrently.
+ * @return {Stream<X>} new stream containing all events of all inner
+ *  streams, with limited concurrency.
+ */
+Stream.prototype.mergeConcurrently = function(concurrency) {
+	return mergeConcurrently.mergeConcurrently(concurrency);
+};
+
+//-----------------------------------------------------------------------
 // Merging
 
 var merge = require('./lib/combinator/merge');

--- a/most.js
+++ b/most.js
@@ -305,7 +305,7 @@ exports.mergeConcurrently = mergeConcurrently.mergeConcurrently;
  *  streams, with limited concurrency.
  */
 Stream.prototype.mergeConcurrently = function(concurrency) {
-	return mergeConcurrently.mergeConcurrently(concurrency);
+	return mergeConcurrently.mergeConcurrently(concurrency, this);
 };
 
 //-----------------------------------------------------------------------

--- a/test/combinator/mergeConcurrently-test.js
+++ b/test/combinator/mergeConcurrently-test.js
@@ -1,0 +1,80 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var mergeConcurrently = require('../../lib/combinator/mergeConcurrently').mergeConcurrently;
+var periodic = require('../../lib/source/periodic').periodic;
+var take = require('../../lib/combinator/slice').take;
+var just = require('../../lib/source/core').of;
+var core = require('../../lib/source/core');
+var fromArray = require('../../lib/source/fromArray').fromArray;
+var TestScheduler = require('../helper/TestScheduler');
+
+var sentinel = { value: 'sentinel' };
+
+describe('mergeConcurrently', function() {
+	it('should be identity for 1 stream', function() {
+		var s = mergeConcurrently(1, just(periodic(1, sentinel)));
+
+		var n = 3;
+		var scheduler = new TestScheduler();
+		scheduler.tick(n);
+
+		return scheduler.collect(take(n, s)).then(function(events) {
+			expect(events).toEqual([
+				{ time: 0, value: sentinel },
+				{ time: 1, value: sentinel },
+				{ time: 2, value: sentinel }
+			]);
+		});
+	});
+
+	it('should merge all when number of streams <= concurrency', function() {
+		var streams = [periodic(1, 1), periodic(1, 2), periodic(1, 3)];
+		var s = mergeConcurrently(streams.length, fromArray(streams));
+
+		var n = 3;
+		var scheduler = new TestScheduler();
+		scheduler.tick(n);
+
+		return scheduler.collect(take(n*streams.length, s)).then(function(events) {
+			expect(events).toEqual([
+				{ time: 0, value: 1 },
+				{ time: 0, value: 2 },
+				{ time: 0, value: 3 },
+				{ time: 1, value: 1 },
+				{ time: 1, value: 2 },
+				{ time: 1, value: 3 },
+				{ time: 2, value: 1 },
+				{ time: 2, value: 2 },
+				{ time: 2, value: 3 }
+			]);
+		});
+
+	});
+
+	it('should merge up to concurrency', function() {
+		var n = 3;
+		var m = 2;
+
+		var streams = [take(n, periodic(1, 1)), take(n, periodic(1, 2)), take(n, periodic(1, 3))];
+		var s = mergeConcurrently(m, fromArray(streams));
+
+		var scheduler = new TestScheduler();
+		scheduler.tick(m*n);
+
+		return scheduler.collect(take(n*streams.length, s)).then(function(events) {
+			expect(events).toEqual([
+				{ time: 0, value: 1 },
+				{ time: 0, value: 2 },
+				{ time: 1, value: 1 },
+				{ time: 1, value: 2 },
+				{ time: 2, value: 1 },
+				{ time: 2, value: 2 },
+				{ time: 2, value: 3 },
+				{ time: 3, value: 3 },
+				{ time: 4, value: 3 }
+			]);
+		});
+
+	});
+});


### PR DESCRIPTION
It's used to implement join, flatMap, and concatMap, so is a generally useful building block.  I don't see any reason not to make it available.  We can bikeshed the name :)

Still needs:

- [x] docs
- [x] unit tests