### PR TITLE
Improve scan initial value handling.

### DIFF
--- a/lib/combinator/accumulate.js
+++ b/lib/combinator/accumulate.js
@@ -5,6 +5,7 @@
 var Stream = require('../Stream');
 var Pipe = require('../sink/Pipe');
 var runSource = require('../runSource');
+var cons = require('./build').cons;
 var noop = require('../base').noop;
 
 exports.scan = scan;
@@ -19,32 +20,16 @@ exports.reduce = reduce;
  * @returns {Stream} new stream containing successive reduce results
  */
 function scan(f, initial, stream) {
-	return new Stream(new Scan(f, initial, stream.source));
+	return cons(initial, new Stream(new Accumulate(ScanSink, f, initial, stream.source)));
 }
-
-function Scan(f, z, source) {
-	this.f = f;
-	this.value = z;
-	this.source = source;
-}
-
-Scan.prototype.run = function(sink, scheduler) {
-	return this.source.run(new ScanSink(this.f, this.value, sink), scheduler);
-};
 
 function ScanSink(f, z, sink) {
 	this.f = f;
 	this.value = z;
 	this.sink = sink;
-	this.init = true;
 }
 
 ScanSink.prototype.event = function(t, x) {
-	if(this.init) {
-		this.init = false;
-		this.sink.event(t, this.value);
-	}
-
 	var f = this.f;
 	this.value = f(this.value, x);
 	this.sink.event(t, this.value);
@@ -63,17 +48,18 @@ ScanSink.prototype.end = Pipe.prototype.end;
  * @returns {Promise} promise for the file result of the reduce
  */
 function reduce(f, initial, stream) {
-	return runSource.withDefaultScheduler(noop, new Accumulate(f, initial, stream.source));
+	return runSource.withDefaultScheduler(noop, new Accumulate(AccumulateSink, f, initial, stream.source));
 }
 
-function Accumulate(f, z, source) {
+function Accumulate(SinkType, f, z, source) {
+	this.SinkType = SinkType;
 	this.f = f;
 	this.value = z;
 	this.source = source;
 }
 
 Accumulate.prototype.run = function(sink, scheduler) {
-	return this.source.run(new AccumulateSink(this.f, this.value, sink), scheduler);
+	return this.source.run(new this.SinkType(this.f, this.value, sink), scheduler);
 };
 
 function AccumulateSink(f, z, sink) {

--- a/lib/combinator/build.js
+++ b/lib/combinator/build.js
@@ -4,11 +4,9 @@
 
 var Stream = require('../Stream');
 var streamOf = require('../source/core').of;
-var fromArray = require('../source/fromArray').fromArray;
-var concatMap = require('./concatMap').concatMap;
+var flatMapEnd = require('./flatMapEnd').flatMapEnd;
 var Sink = require('../sink/Pipe');
 var Promise = require('../Promise');
-var identity = require('../base').identity;
 
 exports.concat = concat;
 exports.cycle = cycle;
@@ -30,7 +28,11 @@ function cons(x, stream) {
  *  events in right.  This *timeshifts* right to the end of left.
  */
 function concat(left, right) {
-	return concatMap(identity, fromArray([left, right]));
+	return flatMapEnd(returnRight, left);
+
+	function returnRight() {
+		return right;
+	}
 }
 
 /**

--- a/test/combinator/sample-test.js
+++ b/test/combinator/sample-test.js
@@ -40,22 +40,22 @@ describe('sample', function() {
 	});
 
 	it('should sample latest value', function() {
-		var s1 = scan(inc, 0, periodic(2));
+		var s1 = scan(inc, 0, periodic(3));
 		var s2 = scan(inc, 0, periodic(1));
 
-		var s = sample.sample(Array, periodic(1), s1, s2);
+		var s = sample.sample(Array, periodic(3), s1, s2);
 
 		var scheduler = new TestScheduler();
-		scheduler.tick(5);
+		scheduler.tick(15);
 
 		return scheduler.collect(take(5, s))
 			.then(function(events) {
 				expect(events).toEqual([
-					{ time: 0, value: [1, 1] },
-					{ time: 1, value: [1, 2] },
-					{ time: 2, value: [2, 3] },
-					{ time: 3, value: [2, 4] },
-					{ time: 4, value: [3, 5] }
+					{ time: 0, value: [0, 0] },
+					{ time: 3, value: [1, 3] },
+					{ time: 6, value: [2, 6] },
+					{ time: 9, value: [3, 9] },
+					{ time: 12, value: [4, 12] }
 				]);
 			});
 	});


### PR DESCRIPTION
This also vastly speeds up startWith and concat by relying on flatMapEnd instead of concatMap.

Fix #175