### PR TITLE
Add continueWith and recoverWith as proposed new names

### DIFF
--- a/most.js
+++ b/most.js
@@ -267,6 +267,7 @@ Stream.prototype.join = function() {
 
 var flatMapEnd = require('./lib/combinator/flatMapEnd').flatMapEnd;
 
+exports.continueWith = flatMapEnd;
 exports.flatMapEnd = flatMapEnd;
 
 /**
@@ -276,7 +277,7 @@ exports.flatMapEnd = flatMapEnd;
  * @returns {Stream} new stream that emits all events from the original stream,
  * followed by all events from the stream returned by f.
  */
-Stream.prototype.flatMapEnd = function(f) {
+Stream.prototype.continueWith = Stream.prototype.flatMapEnd = function(f) {
 	return flatMapEnd(f, this);
 };
 
@@ -642,6 +643,7 @@ Stream.prototype.await = function() {
 
 var errors = require('./lib/combinator/errors');
 
+exports.recoverWith  = errors.flatMapError;
 exports.flatMapError = errors.flatMapError;
 exports.throwError   = errors.throwError;
 
@@ -654,7 +656,7 @@ exports.throwError   = errors.throwError;
  * @param {function(error:*):Stream} f function which returns a new stream
  * @returns {Stream} new stream which will recover from an error by calling f
  */
-Stream.prototype.flatMapError = function(f) {
+Stream.prototype.recoverWith = Stream.prototype.flatMapError = function(f) {
 	return errors.flatMapError(f, this);
 };
 

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -41,3 +41,19 @@ describe('skipUntil', function() {
 		expect(most.Stream.prototype.skipUntil).toBe(most.Stream.prototype.since);
 	});
 });
+
+describe('flatMapEnd', function() {
+	it('should be an alias for continueWith', function() {
+		expect(typeof most.flatMapEnd).toBe('function');
+		expect(most.flatMapEnd).toBe(most.continueWith);
+		expect(most.Stream.prototype.flatMapEnd).toBe(most.Stream.prototype.continueWith);
+	});
+
+	describe('flatMapError', function() {
+		it('should be an alias for recoverWith', function () {
+			expect(typeof most.flatMapError).toBe('function');
+			expect(most.flatMapError).toBe(most.recoverWith);
+			expect(most.Stream.prototype.flatMapError).toBe(most.Stream.prototype.recoverWith);
+		});
+	});
+});


### PR DESCRIPTION
for flatMapEnd and flatMapError.

During discussion on [gitter](https://gitter.im/cujojs/most), we settled initially on `continueWith`, and `recoverWith`.  Those aren't set in stone yet, but definitely are the strongest contenders.

Feedback and other naming suggestions welcome!