### PR TITLE
Fix await() name conflict w/es7 await

### DIFF
--- a/lib/combinator/promises.js
+++ b/lib/combinator/promises.js
@@ -7,7 +7,7 @@ var Promise = require('../Promise');
 var fatal = require('../fatalError');
 
 exports.fromPromise = fromPromise;
-exports.await = await;
+exports.awaitPromises = awaitPromises;
 
 /**
  * Create a stream containing only the promise's fulfillment
@@ -69,7 +69,7 @@ PromiseProducer.prototype.dispose = function() {
  * @return {Stream<T>} stream of fulfillment values.  The stream will
  * error if any promise rejects.
  */
-function await(stream) {
+function awaitPromises(stream) {
 	return new Stream(new Await(stream.source));
 }
 

--- a/most.js
+++ b/most.js
@@ -627,7 +627,7 @@ Stream.prototype.debounce = function(period) {
 var promises = require('./lib/combinator/promises');
 
 exports.fromPromise = promises.fromPromise;
-exports.await       = promises.await;
+exports.await       = promises.awaitPromises;
 
 /**
  * Await promises, turning a Stream<Promise<X>> into Stream<X>.  Preserves
@@ -635,7 +635,7 @@ exports.await       = promises.await;
  * @returns {Stream<X>} stream containing non-promise values
  */
 Stream.prototype.await = function() {
-	return promises.await(this);
+	return promises.awaitPromises(this);
 };
 
 //-----------------------------------------------------------------------

--- a/test/combinator/promises-test.js
+++ b/test/combinator/promises-test.js
@@ -14,7 +14,7 @@ var sentinel = { value: 'sentinel' };
 describe('await', function() {
 
 	it('should await promises', function() {
-		var s = promises.await(streamOf(Promise.resolve(sentinel)));
+		var s = promises.awaitPromises(streamOf(Promise.resolve(sentinel)));
 
 		return observe(function(x) {
 			expect(x).toBe(sentinel);
@@ -28,7 +28,7 @@ describe('await', function() {
 		var fast = Promise.resolve(sentinel);
 
 		// delayed promise followed by already fulfilled promise
-		var s = promises.await(fromArray([slow, fast]));
+		var s = promises.awaitPromises(fromArray([slow, fast]));
 
 		return reduce(function (a, x) {
 			return a.concat(x);
@@ -38,7 +38,7 @@ describe('await', function() {
 	});
 
 	it('should propagate error if promise rejects', function() {
-		var s = promises.await(fromArray([Promise.resolve(), Promise.reject(sentinel), Promise.resolve()]));
+		var s = promises.awaitPromises(fromArray([Promise.resolve(), Promise.reject(sentinel), Promise.resolve()]));
 		var spy = this.spy();
 		return observe(spy, s).catch(function(e) {
 			expect(e).toBe(sentinel);


### PR DESCRIPTION
This doesn't change the public API.  It only fixes the use of `await` as an identifier in lib/combinator/promises.js

Fix #184