### PR TITLE
Expose mergeArray and combineArray

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1092,6 +1092,21 @@ Merging multiple streams creates a new stream containing all events from the inp
 
 In contrast to `concat`, `merge` preserves the arrival times of events. That is, it creates a new stream where events from `stream1` and `stream2` can interleave.
 
+### mergeArray
+
+####`most.mergeArray(arrayOfStreams) -> Stream`
+
+Array form of [merge](#merge).  Create a new Stream containing all events from all streams in `arrayOfStreams`.
+
+```
+s1:                             -a--b----c--->
+s2:                             --w---x-y--z->
+s3:                             ---1---2----3>
+most.mergeArray([s1, s2, s3]):  -aw1b-x2yc-z3>
+```
+
+See [merge](#merge) for more details.
+
 ### combine
 
 ####`stream1.combine(f, stream2) -> Stream`
@@ -1138,6 +1153,21 @@ resultStream.observe(function(z) {
 	resultNode.textContent = z;
 });
 ```
+
+### combineArray
+
+####`most.combineArray(f, arrayOfStreams) -> Stream`
+
+Array form of [combine](#combine). Create a new stream that emits the set of latest event values from all input streams whenever a new event arrives on any input stream.
+
+```
+s1:                                    -0--1----2->
+s2:                                    --3---4-5-->
+s3:                                    ---2---1--->
+most.combineArray(add3, [s1, s2, s3]): ---56-7678->
+```
+
+See [combine](#combine) for more details.
 
 ### sample
 

--- a/most.js
+++ b/most.js
@@ -315,6 +315,7 @@ Stream.prototype.mergeConcurrently = function(concurrency) {
 var merge = require('./lib/combinator/merge');
 
 exports.merge = merge.merge;
+exports.mergeArray = merge.mergeArray;
 
 /**
  * Merge this stream and all the provided streams
@@ -332,6 +333,7 @@ Stream.prototype.merge = function(/*...streams*/) {
 var combine = require('./lib/combinator/combine');
 
 exports.combine = combine.combine;
+exports.combineArray = combine.combineArray;
 
 /**
  * Combine latest events from all input streams

--- a/test/combine-test.js
+++ b/test/combine-test.js
@@ -1,7 +1,7 @@
 require('buster').spec.expose();
 var expect = require('buster').expect;
 
-var combine = require('../lib/combinator/combine').combine;
+var combine = require('../lib/combinator/combine');
 var map = require('../lib/combinator/transform').map;
 var take = require('../lib/combinator/slice').take;
 var delay = require('../lib/combinator/delay').delay;
@@ -19,7 +19,7 @@ describe('combine', function() {
 		var s1 = streamOf(1);
 		var s2 = streamOf(sentinel);
 
-		var sc = combine(Array, s1, delay(1, s2));
+		var sc = combine.combine(Array, s1, delay(1, s2));
 
 		return te.collectEvents(sc, te.ticks(2)).then(function(events) {
 			expect(events.length).toBe(1);
@@ -38,7 +38,48 @@ describe('combine', function() {
 			return a2.shift();
 		}, periodic(2)));
 
-		var sc = combine(Array, take(a1.length, s1), take(a2.length, s2));
+		var sc = combine.combine(Array, take(a1.length, s1), take(a2.length, s2));
+
+		return te.collectEvents(sc, te.ticks(a1.length+a2.length))
+			.then(function(events) {
+				expect(events).toEqual([
+					{ time: 1, value: [ 0, 'a' ] },
+					{ time: 2, value: [ 1, 'a' ] },
+					{ time: 3, value: [ 1, 'b' ] },
+					{ time: 4, value: [ 2, 'b' ] },
+					{ time: 5, value: [ 2, 'c' ] },
+					{ time: 6, value: [ 3, 'c' ] },
+					{ time: 7, value: [ 3, 'd' ] }
+				]);
+			});
+	});
+});
+
+describe('combineArray', function() {
+	it('should yield initial only after all inputs yield', function() {
+		var s1 = streamOf(1);
+		var s2 = streamOf(sentinel);
+
+		var sc = combine.combineArray(Array, [s1, delay(1, s2)]);
+
+		return te.collectEvents(sc, te.ticks(2)).then(function(events) {
+			expect(events.length).toBe(1);
+			expect(events[0].value).toEqual([1, sentinel]);
+		});
+	});
+
+	it('should yield when any input stream yields', function() {
+		var a1 = [0,1,2,3];
+		var s1 = map(function() {
+			return a1.shift();
+		}, periodic(2));
+
+		var a2 = ['a','b','c','d'];
+		var s2 = delay(1, map(function() {
+			return a2.shift();
+		}, periodic(2)));
+
+		var sc = combine.combineArray(Array, [take(a1.length, s1), take(a2.length, s2)]);
 
 		return te.collectEvents(sc, te.ticks(a1.length+a2.length))
 			.then(function(events) {

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -1,5 +1,3 @@
-Updated: 1-5-2016
-
 Latest performance tests of basic most.js operations.
 
 * [Setup](#setup)
@@ -72,6 +70,21 @@ kefir        12.36 op/s ±  1.10%   (32 samples)
 bacon         0.82 op/s ±  3.54%    (7 samples)
 lodash       18.47 op/s ±  2.40%   (34 samples)
 Array         0.41 op/s ±  2.45%    (6 samples)
+-------------------------------------------------------
+
+> most-perf@0.10.0 merge /Users/brian/Projects/cujojs/most/test/perf
+> node ./merge.js
+
+merge 100000 x 10 streams
+-------------------------------------------------------
+most        170.02 op/s ±  1.06%   (76 samples)
+rx 4          1.28 op/s ±  2.66%    (8 samples)
+rx 5          7.65 op/s ±  1.21%   (22 samples)
+kefir        14.51 op/s ±  1.54%   (37 samples)
+bacon         0.88 op/s ±  3.22%    (7 samples)
+highland      0.18 op/s ±  2.32%    (5 samples)
+lodash       17.98 op/s ±  1.97%   (34 samples)
+Array        14.32 op/s ±  2.34%   (39 samples)
 -------------------------------------------------------
 
 > most-perf@0.10.0 zip /Users/brian/Projects/cujojs/most/test/perf

--- a/test/perf/merge.js
+++ b/test/perf/merge.js
@@ -1,0 +1,86 @@
+var Benchmark = require('benchmark');
+var most = require('../../most');
+var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
+var kefir = require('kefir');
+var bacon = require('baconjs');
+var lodash = require('lodash');
+var highland = require('highland');
+
+var runners = require('./runners');
+var kefirFromArray = runners.kefirFromArray;
+
+// flatMapping n streams, each containing m items.
+// Results in a single stream that merges in n x m items
+// In Array parlance: Take an Array containing n Arrays, each of length m,
+// and flatten it to an Array of length n x m.
+var mn = runners.getIntArg2(100000, 10);
+var a = build(mn[0], mn[1]);
+
+function build(m, n) {
+	var a = new Array(n);
+	for(var i = 0; i< a.length; ++i) {
+		a[i] = buildArray(i*1000, m);
+	}
+	return a;
+}
+
+function buildArray(base, n) {
+	var a = new Array(n);
+	for(var i = 0; i< a.length; ++i) {
+		a[i] = base + i;
+	}
+	return a;
+}
+
+var suite = Benchmark.Suite('merge ' + mn[0] + ' x ' + mn[1] + ' streams');
+var options = {
+	defer: true,
+	onError: function(e) {
+		e.currentTarget.failure = e.error;
+	}
+};
+
+suite
+	.add('most', function(deferred) {
+		var streams = a.map(most.from);
+		runners.runMost(deferred, most.mergeArray(streams).reduce(sum, 0));
+	}, options)
+	.add('rx 4', function(deferred) {
+		var streams = a.map(rx.Observable.fromArray);
+		runners.runRx(deferred, rx.Observable.merge.apply(void 0, streams).reduce(sum, 0));
+	}, options)
+	.add('rx 5', function(deferred) {
+		var streams = a.map(function(x) {return rxjs.Observable.fromArray(x)});
+		runners.runRx5(deferred,
+			rxjs.Observable.merge.apply(rxjs.Observable, streams).reduce(sum, 0))
+	}, options)
+	.add('kefir', function(deferred) {
+		var streams = a.map(kefirFromArray);
+		runners.runKefir(deferred, kefir.merge(streams).scan(sum, 0).last());
+	}, options)
+	.add('bacon', function(deferred) {
+		var streams = a.map(bacon.fromArray);
+		runners.runBacon(deferred, bacon.mergeAll(streams).reduce(0, sum));
+	}, options)
+	.add('highland', function(deferred) {
+		// HELP WANTED: Is there a better way to do this in highland?
+		// The two approaches below perform similarly
+		var streams = a.map(highland);
+		runners.runHighland(deferred, highland(streams).merge().reduce(0, sum));
+		//runners.runHighland(deferred, highland(streams).flatMap(identity).reduce(0, sum));
+	}, options)
+	.add('lodash', function() {
+		// "Merge" synchronous arrays by concatenation
+		return lodash(a).flatten().reduce(sum, 0);
+	})
+	.add('Array', function() {
+		// "Merge" synchronous arrays by concatenation
+		return Array.prototype.concat.apply([], a).reduce(sum, 0);
+	});
+
+runners.runSuite(suite);
+
+function sum(x, y) {
+	return x + y;
+}

--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -8,10 +8,11 @@
     "concatMap": "node ./concatMap.js",
     "filter-map-reduce": "node ./filter-map-reduce",
     "flatMap": "node ./flatMap.js",
+    "merge": "node ./merge.js",
     "scan": "node ./scan.js",
     "skipRepeats": "node ./skipRepeats.js",
     "zip": "node ./zip.js",
-    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run zip && npm run scan && npm run skipRepeats"
+    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run zip && npm run scan && npm run skipRepeats"
   },
   "dependencies": {
     "@reactivex/rxjs": "^5.0.0-beta.0",


### PR DESCRIPTION
This exposes the existing array versions of merge and combine, since they can be useful at times, and `.apply(undefined, streams)` is ugly.

Docs and unit test update included.  This also adds a perf test for merge.