### PR TITLE
Improve merge perf

### DIFF
--- a/lib/combinator/merge.js
+++ b/lib/combinator/merge.js
@@ -2,10 +2,15 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var empty = require('../Stream').empty;
-var fromArray = require('../source/fromArray').fromArray;
-var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
-var copy = require('../base').copy;
+var Stream = require('../Stream');
+var Pipe = require('../sink/Pipe');
+var IndexSink = require('../sink/IndexSink');
+var empty = require('../source/core').empty;
+var dispose = require('../disposable/dispose');
+var base = require('../base');
+
+var copy = base.copy;
+var map = base.map;
 
 exports.merge = merge;
 exports.mergeArray = mergeArray;
@@ -29,5 +34,46 @@ function mergeArray(streams) {
 	var l = streams.length;
     return l === 0 ? empty()
 		 : l === 1 ? streams[0]
-		 : mergeConcurrently(l, fromArray(streams));
+		 : new Stream(new Merge(map(getSource, streams)));
 }
+
+function getSource(s) {
+	return s.source;
+}
+
+function Merge(sources) {
+	this.sources = sources;
+	this.activeCount = sources.length;
+}
+
+Merge.prototype.run = function(sink, scheduler) {
+	var l = this.sources.length;
+	var disposables = new Array(l);
+	var sinks = new Array(l);
+
+	var mergeSink = new MergeSink(sinks, sink);
+
+	for(var indexSink, i=0; i<l; ++i) {
+		indexSink = sinks[i] = new IndexSink(i, mergeSink);
+		disposables[i] = this.sources[i].run(indexSink, scheduler);
+	}
+
+	return dispose.all(disposables);
+};
+
+function MergeSink(sinks, sink) {
+	this.sink = sink;
+	this.activeCount = sinks.length;
+}
+
+MergeSink.prototype.error = Pipe.prototype.error;
+
+MergeSink.prototype.event = function(t, indexValue) {
+	this.sink.event(t, indexValue.value);
+};
+
+MergeSink.prototype.end = function(t, indexedValue) {
+	if(--this.activeCount === 0) {
+		this.sink.end(t, indexedValue.value);
+	}
+};

--- a/test/perf/README.md
+++ b/test/perf/README.md
@@ -77,14 +77,14 @@ Array         0.41 op/s ±  2.45%    (6 samples)
 
 merge 100000 x 10 streams
 -------------------------------------------------------
-most        170.02 op/s ±  1.06%   (76 samples)
-rx 4          1.28 op/s ±  2.66%    (8 samples)
-rx 5          7.65 op/s ±  1.21%   (22 samples)
-kefir        14.51 op/s ±  1.54%   (37 samples)
-bacon         0.88 op/s ±  3.22%    (7 samples)
-highland      0.18 op/s ±  2.32%    (5 samples)
-lodash       17.98 op/s ±  1.97%   (34 samples)
-Array        14.32 op/s ±  2.34%   (39 samples)
+most        319.76 op/s ±  1.58%   (78 samples)
+rx 4          1.24 op/s ±  1.42%    (8 samples)
+rx 5          7.84 op/s ±  1.01%   (23 samples)
+kefir        14.66 op/s ±  1.28%   (37 samples)
+bacon         0.90 op/s ±  2.31%    (7 samples)
+highland      0.18 op/s ±  2.61%    (5 samples)
+lodash       18.07 op/s ±  1.47%   (34 samples)
+Array        14.05 op/s ±  2.24%   (39 samples)
 -------------------------------------------------------
 
 > most-perf@0.10.0 zip /Users/brian/Projects/cujojs/most/test/perf


### PR DESCRIPTION
This uses a specialized merge implementation instead of `mergeConcurrently` to get almost 2x improvement, at the cost of about 50 min+gzipped *bytes*.  Seems worth it.