### PR TITLE
Safely dispose in the face of exceptions

### DIFF
--- a/lib/disposable/dispose.js
+++ b/lib/disposable/dispose.js
@@ -27,7 +27,7 @@ exports.promised = promised;
  * @return {*} result of disposable.dispose
  */
 function tryDispose(t, disposable, sink) {
-	var result = disposable.dispose();
+	var result = disposeSafely(disposable);
 	return isPromise(result)
 		? result.catch(function (e) {
 			sink.error(t, e);
@@ -65,11 +65,15 @@ function all(disposables) {
 }
 
 function disposeAll(disposables) {
-	return Promise.all(map(disposeOne, disposables));
+	return Promise.all(map(disposeSafely, disposables));
 }
 
-function disposeOne(disposable) {
-	return disposable.dispose();
+function disposeSafely(disposable) {
+	try {
+		return disposable.dispose();
+	} catch(e) {
+		return Promise.reject(e);
+	}
 }
 
 /**
@@ -83,6 +87,10 @@ function promised(disposablePromise) {
 
 function disposePromise(disposablePromise) {
 	return disposablePromise.then(disposeOne);
+}
+
+function disposeOne(disposable) {
+	return disposable.dispose();
 }
 
 /**
@@ -107,7 +115,7 @@ function once(disposable) {
 function disposeMemoized(memoized) {
 	if(!memoized.disposed) {
 		memoized.disposed = true;
-		memoized.value = memoized.disposable.dispose();
+		memoized.value = disposeSafely(memoized.disposable);
 		memoized.disposable = void 0;
 	}
 

--- a/test/disposable/Disposable-test.js
+++ b/test/disposable/Disposable-test.js
@@ -1,0 +1,18 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var Disposable = require('../../lib/disposable/Disposable');
+
+describe('Disposable', function() {
+	it('should call disposer with data', function() {
+		var spy = this.spy(function(x) {
+			return x;
+		});
+		var data = {};
+
+		var d = new Disposable(spy, data);
+
+		expect(d.dispose()).toBe(data);
+		expect(spy).toHaveBeenCalledOnceWith(data);
+	});
+});

--- a/test/disposable/SettableDisposable-test.js
+++ b/test/disposable/SettableDisposable-test.js
@@ -1,0 +1,44 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var SettableDisposable = require('../../lib/disposable/SettableDisposable');
+
+describe('SettableDisposable', function() {
+	it('should allow setDisposable before dispose', function() {
+		var d = new SettableDisposable();
+		var data = {};
+
+		d.setDisposable({
+			dispose: function() { return data; }
+		});
+
+		var x = d.dispose();
+
+		expect(x).toBe(data);
+	});
+
+	it('should allow setDisposable after dispose', function() {
+		var d = new SettableDisposable();
+		var data = {};
+
+		var p = d.dispose();
+
+		d.setDisposable({
+			dispose: function() { return data; }
+		});
+
+		return p.then(function(x) {
+			expect(x).toBe(data);
+		});
+	});
+
+	it('should allow setDisposable at most once', function() {
+		var d = new SettableDisposable();
+
+		d.setDisposable({});
+
+		expect(function() {
+			d.setDisposable({});
+		}).toThrow();
+	});
+});

--- a/test/disposable/dispose-test.js
+++ b/test/disposable/dispose-test.js
@@ -1,0 +1,277 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var dispose = require('../../lib/disposable/dispose');
+
+function noop() {}
+
+function throws(e) {
+	throw e;
+}
+
+function rejects(e) {
+	return Promise.reject(e);
+}
+
+function returns(x) {
+	return x;
+}
+
+function disposableSpy(f, x) {
+	return {
+		called: 0,
+		dispose: function() {
+			this.called++;
+			return f(x);
+		}
+	};
+}
+
+function called(n) {
+	return function(d) {
+		return d.called === n;
+	}
+}
+
+var calledOnce = called(1);
+
+var failSink = {
+	error: function(t, e) {
+		throw e;
+	}
+};
+
+function catchSink() {
+	return {
+		time: NaN,
+		value: {},
+		error: function(t, e) {
+			this.time = t;
+			this.value = e;
+		}
+	}
+}
+
+describe('tryDispose', function() {
+	it('should return disposable result', function() {
+		var x = {};
+		var spy = disposableSpy(returns, x);
+
+		var result = dispose.tryDispose(0, spy, failSink);
+		expect(result).toBe(x);
+	});
+
+	it('should return disposable result promise', function() {
+		var x = {};
+		var spy = disposableSpy(returns, Promise.resolve(x));
+
+		return dispose.tryDispose(0, spy, failSink).then(function(y) {
+			expect(y).toBe(x);
+		});
+	});
+
+	it('should propagate error if disposable throws', function() {
+		var x = {};
+		var spy = disposableSpy(throws, x);
+
+		var sink = catchSink();
+		var t = Math.random();
+		return dispose.tryDispose(t, spy, sink).then(function() {
+			expect(sink.time).toBe(t);
+			expect(sink.value).toBe(x);
+		});
+	});
+
+	it('should propagate error if disposable rejects', function() {
+		var x = {};
+		var spy = disposableSpy(returns, Promise.reject(x));
+
+		var sink = catchSink();
+		var t = Math.random();
+		return dispose.tryDispose(t, spy, sink).then(function() {
+			expect(sink.time).toBe(t);
+			expect(sink.value).toBe(x);
+		});
+	});
+});
+
+describe('dispose.all', function() {
+
+	it('should dispose all', function() {
+		var disposables = [
+			disposableSpy(noop),
+			disposableSpy(returns, 123),
+			disposableSpy(returns, Promise.resolve())
+		];
+
+		return dispose.all(disposables).dispose().then(function(results) {
+			expect(results).toBeArray();
+			expect(disposables.every(calledOnce)).toBeTrue();
+		});
+	});
+
+	it('should dispose all nested', function() {
+		var nested = [
+			disposableSpy(noop),
+			disposableSpy(returns, 123),
+			disposableSpy(returns, Promise.resolve())
+		];
+		var disposables = [
+			disposableSpy(noop),
+			dispose.all(nested),
+			disposableSpy(noop)
+		];
+
+		return dispose.all(disposables).dispose().then(function(results) {
+			expect(results).toBeArray();
+			expect(nested.every(calledOnce)).toBeTrue();
+		});
+
+	});
+
+	it('should dispose all regardless of errors', function() {
+		var disposables = [
+			disposableSpy(noop),
+			disposableSpy(throws, new Error()),
+			disposableSpy(rejects, new Error()),
+			disposableSpy(noop)
+		];
+
+		return dispose.all(disposables).dispose().then(
+			function() {
+				throw new Error('should not have disposed successfully');
+			},
+			function() {
+				expect(disposables.every(calledOnce)).toBeTrue();
+			});
+	});
+
+	it('should dispose nested regardless of errors', function() {
+		var nested = [
+			disposableSpy(noop),
+			disposableSpy(throws, new Error()),
+			disposableSpy(rejects, new Error()),
+			disposableSpy(noop)
+		];
+
+		var disposables = [
+			disposableSpy(throws, new Error()),
+			dispose.all(nested),
+			disposableSpy(rejects, new Error())
+		];
+
+		return dispose.all(disposables).dispose().then(
+			function() {
+				throw new Error('should not have disposed successfully');
+			},
+			function() {
+				expect(nested.every(calledOnce)).toBeTrue();
+			});
+	});
+
+});
+
+describe('dispose.once', function() {
+	it('should call underlying dispose', function() {
+		var x = {};
+		var spy = disposableSpy(returns, x);
+		var d = dispose.once(spy);
+
+		var result = d.dispose();
+
+		expect(result).toBe(x);
+		expect(calledOnce(spy)).toBeTrue();
+	});
+
+	it('should call underlying dispose at most once', function() {
+		var x = {};
+		var spy = disposableSpy(returns, x);
+		var d = dispose.once(spy);
+
+		expect(d.dispose()).toBe(d.dispose());
+		expect(calledOnce(spy)).toBeTrue();
+	});
+});
+
+describe('dispose.create', function() {
+	it('should call dispose function with data', function() {
+		var x = {};
+		var y;
+		var d = dispose.create(function(x) {
+			return y = x;
+		}, x);
+
+		var result = d.dispose();
+
+		expect(result).toBe(x);
+		expect(y).toBe(x);
+	});
+
+	it('should call dispose function at most once', function() {
+		var x = 0;
+		var d = dispose.create(function() {
+			return x++;
+		});
+
+		d.dispose();
+		d.dispose();
+
+		expect(x).toBe(1);
+	});
+});
+
+describe('dispose.empty', function() {
+	it('should return undefined', function() {
+		expect(dispose.empty().dispose()).toBe(void 0);
+	});
+});
+
+describe('dispose.promised', function() {
+	it('should dispose promised disposable', function() {
+		var x = {};
+		var spy = disposableSpy(returns, x);
+		var d = dispose.promised(Promise.resolve(spy));
+
+		return d.dispose().then(function(y) {
+			expect(y).toBe(x);
+			expect(calledOnce(spy)).toBeTrue();
+		});
+	});
+
+	it('should return rejected promise if disposable rejects', function() {
+		var x = {};
+		var spy = disposableSpy(returns, Promise.reject(x));
+		var d = dispose.promised(Promise.resolve(spy));
+
+		return d.dispose().then(function() {
+			throw new Error('should not fulfill');
+		}, function(e) {
+			expect(e).toBe(x);
+			expect(calledOnce(spy)).toBeTrue();
+		});
+	});
+
+	it('should return rejected promise if disposable throws', function() {
+		var x = {};
+		var spy = disposableSpy(throws, x);
+		var d = dispose.promised(Promise.resolve(spy));
+
+		return d.dispose().then(function() {
+			throw new Error('should not fulfill');
+		}, function(e) {
+			expect(e).toBe(x);
+			expect(calledOnce(spy)).toBeTrue();
+		});
+	});
+
+	it('should not dispose promised disposable if rejected', function() {
+		var x = {};
+		var d = dispose.promised(Promise.reject(x));
+
+		return d.dispose().then(function() {
+			throw new Error('should not fulfill');
+		}, function(e) {
+			expect(e).toBe(x);
+		});
+	});
+});


### PR DESCRIPTION
Disposal was previously safe in the face of rejected promises.  That is, all other resources would be disposed even if one or more of them failed by returning a rejected promise.  Disposal was not safe in the face of exceptions.

There are 2 ways to handle thrown exceptions during disposal:

1. Declare that disposables *must not throw*, and any disposable that does is broken and should be fixed, or
2. Catch exceptions and turn them into rejected promises, and let the current machinery handle them safely.

This PR does 2.  However, I'm not convinced it's the right thing, since it allows callers to be less rigorous.  So, feedback and discussion welcome!

This also adds unit test coverage for disposables.  If we decide to go with option 1, we can remove the one `try/catch` spot in `disposeSafely`, and keep the unit test coverage (except for the tests that specifically deal with thrown exceptions).