### PR TITLE
Make error architecture less aggressive

### DIFF
--- a/lib/combinator/errors.js
+++ b/lib/combinator/errors.js
@@ -5,6 +5,7 @@
 var Stream = require('../Stream');
 var ValueSource = require('../source/ValueSource');
 var tryDispose = require('../disposable/dispose').tryDispose;
+var tryEvent = require('../source/tryEvent');
 var apply = require('../base').apply;
 
 exports.flatMapError = recoverWith;
@@ -68,14 +69,14 @@ RecoverWithSink.prototype.event = function(t, x) {
 	if(!this.active) {
 		return;
 	}
-	this.sink.event(t, x);
+	tryEvent.tryEvent(t, x, this.sink);
 };
 
 RecoverWithSink.prototype.end = function(t, x) {
 	if(!this.active) {
 		return;
 	}
-	this.sink.end(t, x);
+	tryEvent.tryEnd(t, x, this.sink);
 };
 
 RecoverWithSink.prototype.dispose = function() {


### PR DESCRIPTION
The error architecture was slightly too aggressive, allowing `recoverWith` to recover from errors that occur later in the sink chain.  It should only recover from errors that occur earlier.  The specific change in this PR, while perhaps slightly counterintuitive at first, makes error handling more intuitive for users.

Using the words "backwards" and "forwards", and "before" and "after" is a little weird, but, imho, makes for a good mental model.

#### Source and sink chains

Applying combinators to a stream effectively composes a *source chain* that defines the behavior of the stream.  When an observer begins observing a stream, a "run" message is sent "backwards" through the source chain, from the observer to the ultimate producer source--the one that will produce events in the first place.  As it travels, that message builds up a *sink chain*, analogous to the source chain.  The producer begins producing events.  With the exception of a few combinators, events then propagate *synchronously* "forward" through the sink chain.

#### Event and exception propagation

Each event propagation is effectively a synchronous call stack.  If an exception is thrown during event synchronous propagation, it will stop the propagation and travel "backwards" through the sink chain, unwinding the call stack (this bit is important).  If nothing catches it, it will reach the producer, and then finally, the scheduler.  The scheduler will catch it and send the error "forward" through the sink chain again (using the `error` channel).

The "backward" propagation of thrown exceptions through the sink chain allowed an error in a later sink to propagate back past `recoverWith`, ultimately hit the scheduler, which then sent it "forward" again, allowing `recoverWith` to intercept it and recover.

Allowing `recoverWith` to recover from errors that happen "after" it in the sink chain is unintuitive: a particular `recoverWith` should only be able to see errors that happen "before" it.

#### Solution

The solution is also somewhat counterintuitive.  As an exception travels "backwards" through the sink chain, if it arrives at a `recoverWith` node, that `recoverWith` will catch it and immediately send it forward using the `error` channel.
