### PR TITLE
Deprecate cycle()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -478,6 +478,8 @@ Note that this effectively *timeshifts* events from `stream2` past the end time 
 
 ### cycle
 
+**Deprecated**
+
 ####`stream.cycle() -> Stream`
 ####`most.cycle(stream) -> Stream`
 

--- a/lib/combinator/build.js
+++ b/lib/combinator/build.js
@@ -31,6 +31,7 @@ function concat(left, right) {
 }
 
 /**
+ * @deprecated
  * Tie stream into a circle, creating an infinite stream
  * @param {Stream} stream
  * @returns {Stream} new infinite stream

--- a/most.js
+++ b/most.js
@@ -149,6 +149,7 @@ exports.concat    = build.concat;
 exports.startWith = build.cons;
 
 /**
+ * @deprecated
  * Tie this stream into a circle, thus creating an infinite stream
  * @returns {Stream} new infinite stream
  */


### PR DESCRIPTION
It doesn't seem to be useful.  If there's a need for it, it could be published as a separate package.

We can release 0.18.1 with the deprecation, and remove it in 0.19.0.