### PR TITLE
Update reqr.es links in example.

### DIFF
--- a/docs/recipes/unfold-promises.md
+++ b/docs/recipes/unfold-promises.md
@@ -19,9 +19,9 @@ the last.
 
 ```js
 var most = require('most');
-var urls = ['http://reqr.es/api/users?page=2', 
-            'http://reqr.es/api/users?delay=3', 
-            'http://reqr.es/api/users?page=3'];
+var urls = ['http://reqres.in/api/users?page=2', 
+            'http://reqres.in/api/users?delay=3', 
+            'http://reqres.in/api/users?page=3'];
 
 most.unfold(function (urls) {
     return urls.length === 0 


### PR DESCRIPTION
It looks like reqr.es has done away and the project is now hosted at reqres.in . I'm not sure what the api returned before - I'm assuming it is similar.