### PR TITLE
Fix scheduler cancelAll

### DIFF
--- a/lib/combinator/mergeConcurrently.js
+++ b/lib/combinator/mergeConcurrently.js
@@ -51,7 +51,7 @@ Outer.prototype._startInner = function(t, stream) {
 
 Outer.prototype.end = function(t, x) {
 	this.active = false;
-	this.disposable.dispose();
+	dispose.tryDispose(t, this.disposable, this.sink);
 	this._checkEnd(t, x);
 };
 

--- a/lib/scheduler/Scheduler.js
+++ b/lib/scheduler/Scheduler.js
@@ -87,9 +87,15 @@ Scheduler.prototype.cancel = function(task) {
 };
 
 Scheduler.prototype.cancelAll = function(f) {
-	this._tasks = base.removeAll(f, this._tasks);
+	for(var i=0; i<this._tasks.length; ++i) {
+		removeAllFrom(f, this._tasks[i]);
+	}
 	this._reschedule();
 };
+
+function removeAllFrom(f, timeslot) {
+	timeslot.events = base.removeAll(f, timeslot.events);
+}
 
 Scheduler.prototype._reschedule = function() {
 	if(this._tasks.length === 0) {

--- a/lib/source/ValueSource.js
+++ b/lib/source/ValueSource.js
@@ -16,10 +16,9 @@ ValueSource.prototype.run = function(sink, scheduler) {
 };
 
 function ValueProducer(emit, x, sink, scheduler) {
-	this.task = new PropagateTask(emit, x, sink);
-	scheduler.asap(this.task);
+	this.task = scheduler.asap(new PropagateTask(emit, x, sink));
 }
 
 ValueProducer.prototype.dispose = function() {
-	return this.task.dispose();
+	return this.task.cancel();
 };


### PR DESCRIPTION
Fix for case that could cause cancelAll to remove the wrong tasks from the scheduler queue.

Couple other small improvements:

1. Use new, safer `tryDispose` in mergeConcurrently.
2. Cancel scheduled task wrapper in ValueSource, instead of only disposing the task itself.  Canceling the scheduled task wrapper removes it from the scheduler *and* disposes the underlying task.