### PR TITLE
Simplify fromPromise using awaitPromises+just.

### DIFF
--- a/lib/combinator/promises.js
+++ b/lib/combinator/promises.js
@@ -4,6 +4,7 @@
 
 var Stream = require('../Stream');
 var fatal = require('../fatalError');
+var just = require('../source/core').of;
 
 exports.fromPromise = fromPromise;
 exports.awaitPromises = awaitPromises;
@@ -16,50 +17,8 @@ exports.awaitPromises = awaitPromises;
  *  If the promise rejects, the stream will error
  */
 function fromPromise(p) {
-	return new Stream(new PromiseSource(p));
+	return awaitPromises(just(p));
 }
-
-function PromiseSource(p) {
-	this.promise = p;
-}
-
-PromiseSource.prototype.run = function(sink, scheduler) {
-	return new PromiseProducer(this.promise, sink, scheduler);
-};
-
-function PromiseProducer(p, sink, scheduler) {
-	this.sink = sink;
-	this.scheduler = scheduler;
-	this.active = true;
-
-	var self = this;
-	Promise.resolve(p).then(function(x) {
-		self._emit(self.scheduler.now(), x);
-	}).catch(function(e) {
-		self._error(self.scheduler.now(), e);
-	});
-}
-
-PromiseProducer.prototype._emit = function(t, x) {
-	if(!this.active) {
-		return;
-	}
-
-	this.sink.event(t, x);
-	this.sink.end(t, void 0);
-};
-
-PromiseProducer.prototype._error = function(t, e) {
-	if(!this.active) {
-		return;
-	}
-
-	this.sink.error(t, e);
-};
-
-PromiseProducer.prototype.dispose = function() {
-	this.active = false;
-};
 
 /**
  * Turn a Stream<Promise<T>> into Stream<T> by awaiting each promise.


### PR DESCRIPTION
This stabilizes sample() and the interaction between `fromPromise()` with *already-fulfilled* promises and `just()`.

[Read this](https://gist.github.com/briancavalier/a27ddc247dd118ae5508) for more information.  It's not clear yet whether this is the best long term solution.  However, it seems reasonable for now, and deletes far more code than it adds.

Close #201