### PR TITLE
Clarify that pulling add/end/error out of closure is unsupported

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -393,8 +393,23 @@ The publisher function can use `add`, `end`, and `error`:
 
 **Important**
 
-* Pulling the `add`, `end`, and/or `error` functions out of the publisher closure is *not supported*.
 * If you never call `end` or `error`, the stream will never end, and consumers will wait forever for additional events.
+
+* Pulling the `add`, `end`, and/or `error` functions out of the publisher closure is *not supported*.
+
+```js
+// Unsupported:
+let emitEvent, emitEnd, emitError
+
+const stream = most.create((add, end, error) => {
+  emitEvent = add
+  emitEnd = end
+  emitError = error
+})
+
+emitEvent(123)
+emitEnd()
+```
 
 #### dispose
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -373,7 +373,7 @@ most.fromEvent('click', container)
 
 ####`most.create(publisher) -> Stream`
 
-Create a push-stream for imperatively pushing events, primarily for adapting existing event sources.
+Create a push-stream for imperatively pushing events, primarily for situations where existing, declarative sources, like [`fromEvent`](#mostfromevent), [`unfold`](#mostunfold), [`iterate`](#mostiterate), etc. can't be used.
 
 ```
 function publisher(add:function(x:*), end:function(x:*), error:function(e:Error))
@@ -391,7 +391,10 @@ The publisher function can use `add`, `end`, and `error`:
 * `end()` - End the stream. Any later calls to `add`, `end`, or `error` will be no-ops.
 * `error(e)` - Signal that the stream has failed and cannot produce more events.
 
-Note that if you never call `end` or `error`, the stream will never end, and consumers will wait forever for additional events.
+**Important**
+
+* Pulling the `add`, `end`, and/or `error` functions out of the publisher closure is *not supported*.
+* If you never call `end` or `error`, the stream will never end, and consumers will wait forever for additional events.
 
 #### dispose
 


### PR DESCRIPTION
This was never the intent of `most.create`, but wasn't really clear in the docs.  Now that `most-subject` exists, there's no reason even to try it.

See #204