### PR TITLE
Implement fusion/flattening for merge

### DIFF
--- a/lib/combinator/combine.js
+++ b/lib/combinator/combine.js
@@ -7,14 +7,13 @@ var transform = require('./transform');
 var core = require('../source/core');
 var Pipe = require('../sink/Pipe');
 var IndexSink = require('../sink/IndexSink');
-var mergeSources = require('./merge').mergeSources;
 var dispose = require('../disposable/dispose');
 var base = require('../base');
 var invoke = require('../invoke');
 
 var hasValue = IndexSink.hasValue;
 
-//var map = base.map;
+var map = base.map;
 var tail = base.tail;
 
 exports.combineArray = combineArray;
@@ -41,8 +40,36 @@ function combineArray(f, streams) {
 	var l = streams.length;
 	return l === 0 ? core.empty()
 		 : l === 1 ? transform.map(f, streams[0])
-		 : new Stream(mergeSources(CombineSink, f, streams));
+		 : new Stream(combineSources(f, streams));
 }
+
+function combineSources(f, streams) {
+	return new Combine(f, map(getSource, streams))
+}
+
+function getSource(stream) {
+	return stream.source;
+}
+
+function Combine(f, sources) {
+	this.f = f;
+	this.sources = sources;
+}
+
+Combine.prototype.run = function(sink, scheduler) {
+	var l = this.sources.length;
+	var disposables = new Array(l);
+	var sinks = new Array(l);
+
+	var mergeSink = new CombineSink(disposables, sinks, sink, this.f);
+
+	for(var indexSink, i=0; i<l; ++i) {
+		indexSink = sinks[i] = new IndexSink(i, mergeSink);
+		disposables[i] = this.sources[i].run(indexSink, scheduler);
+	}
+
+	return dispose.all(disposables);
+};
 
 function CombineSink(disposables, sinks, sink, f) {
 	this.sink = sink;

--- a/lib/combinator/merge.js
+++ b/lib/combinator/merge.js
@@ -10,11 +10,10 @@ var dispose = require('../disposable/dispose');
 var base = require('../base');
 
 var copy = base.copy;
-var map = base.map;
+var reduce = base.reduce;
 
 exports.merge = merge;
 exports.mergeArray = mergeArray;
-exports.mergeSources = mergeSources;
 
 /**
  * @returns {Stream} stream containing events from all streams in the argument
@@ -35,20 +34,30 @@ function mergeArray(streams) {
     var l = streams.length;
     return l === 0 ? empty()
 		 : l === 1 ? streams[0]
-		 : new Stream(mergeSources(MergeSink, void 0, streams));
+		 : new Stream(mergeSources(streams));
 }
 
-function mergeSources(Sink, arg, streams) {
-	return new Merge(Sink, arg, map(getSource, streams))
+/**
+ * This implements fusion/flattening for merge.  It will
+ * fuse adjacent merge operations.  For example:
+ * - a.merge(b).merge(c) effectively becomes merge(a, b, c)
+ * - merge(a, merge(b, c)) effectively becomes merge(a, b, c)
+ * It does this by concatenating the sources arrays of
+ * any nested Merge sources, in effect "flattening" nested
+ * merge operations into a single merge.
+ */
+function mergeSources(streams) {
+	return new Merge(reduce(appendSources, [], streams))
 }
 
-function getSource(stream) {
-	return stream.source;
+function appendSources(sources, stream) {
+	var source = stream.source;
+	return source instanceof Merge
+		? sources.concat(source.sources)
+		: sources.concat(source)
 }
 
-function Merge(Sink, arg, sources) {
-	this.Sink = Sink;
-	this.arg = arg;
+function Merge(sources) {
 	this.sources = sources;
 }
 
@@ -57,7 +66,7 @@ Merge.prototype.run = function(sink, scheduler) {
 	var disposables = new Array(l);
 	var sinks = new Array(l);
 
-	var mergeSink = new this.Sink(disposables, sinks, sink, this.arg);
+	var mergeSink = new MergeSink(disposables, sinks, sink);
 
 	for(var indexSink, i=0; i<l; ++i) {
 		indexSink = sinks[i] = new IndexSink(i, mergeSink);

--- a/test/combinator/merge-test.js
+++ b/test/combinator/merge-test.js
@@ -68,4 +68,3 @@ function toArray(s) {
 		return result.concat(x);
 	}, [], s);
 }
-

--- a/test/perf/merge.js
+++ b/test/perf/merge.js
@@ -10,7 +10,7 @@ var highland = require('highland');
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
 
-// flatMapping n streams, each containing m items.
+// Merging n streams, each containing m items.
 // Results in a single stream that merges in n x m items
 // In Array parlance: Take an Array containing n Arrays, each of length m,
 // and flatten it to an Array of length n x m.


### PR DESCRIPTION
This implements fusion/flattening for adjacent/nested `merge` operations.  This means there is zero performance hit for nested merges.  For example, if a function returns a merged stream to you, and you then merge it with another stream, that structure will be flattened to a single merge.

* `a.merge(b).merge(c)` effectively becomes `merge(a, b, c)`
* `merge(a, merge(b, c))` effectively becomes `merge(a, b, c)`

It works by concatenating the sources arrays of any nested Merge sources, in effect "flattening" nested merge operations into a single merge.

I had to change `combine` so that it doesn't use mergeSources: since combine is *not* associative, it can't be flattened in the same way.
