### PR TITLE
Add mergeMapConcurrently

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -328,7 +328,7 @@ When the stream ends (for example, by using [take](#take), [takeUntil](#until), 
 
 **Notes on EventEmitter**
 
-1. When source event has more than one argument, all the arguments will be aggregated into array in resulting Stream. 
+1. When source event has more than one argument, all the arguments will be aggregated into array in resulting Stream.
 2. EventEmitters and EventTargets, such as DOM nodes, behave differently in that EventEmitter allows events to be delivered in the same tick as a listener is added.  When using EventEmitter, `most.fromEvent`, will *ensure asynchronous event delivery*, thereby preventing hazards of "maybe sync, maybe async" (aka zalgo) event delivery.
 
 ```js
@@ -337,7 +337,7 @@ var clicks = most.fromEvent('click', document.querySelector('.the-button'));
 
 ```js
 // We can do some event delegation by applying a filter to the stream
-// in conjunction with e.target.matches this will allow only events with 
+// in conjunction with e.target.matches this will allow only events with
 // .the-button class to be processed
 var container = document.querySelector('.container');
 most.fromEvent('click', container);
@@ -714,6 +714,8 @@ most.periodic(1000, 'x')
 
 Transform each event in `stream` into a stream, and then concatenate it onto the end of the resulting stream. Note that `f` *must* return a stream.
 
+The mapping function `f` is applied *lazily*.  That is, `f` is called only once it is time to concatenate a new stream.
+
 `function f(x) -> Stream`
 
 ```
@@ -722,6 +724,7 @@ f(a):                 1--2--3|
 f(b):                      1----2----3|
 f(c):                             1-2-3|
 stream.concatMap(f): -1--2--31----2----31-2-3|
+f called lazily:      ^      ^          ^
 ```
 
 Note the difference between [`concatMap`](#concatmap) and [`flatMap`](#flatmap): `concatMap` concatenates, while `flatMap` merges.

--- a/lib/combinator/concatMap.js
+++ b/lib/combinator/concatMap.js
@@ -2,8 +2,7 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
-var map = require('./transform').map;
+var mergeMapConcurrently = require('./mergeConcurrently').mergeMapConcurrently;
 
 exports.concatMap = concatMap;
 
@@ -19,5 +18,5 @@ exports.concatMap = concatMap;
  * @returns {Stream} new stream containing all events from each stream returned by f
  */
 function concatMap(f, stream) {
-	return mergeConcurrently(1, map(f, stream));
+	return mergeMapConcurrently(f, 1, stream);
 }

--- a/lib/combinator/flatMap.js
+++ b/lib/combinator/flatMap.js
@@ -3,7 +3,7 @@
 /** @author John Hann */
 
 var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
-var map = require('./transform').map;
+var mergeMapConcurrently = require('./mergeConcurrently').mergeMapConcurrently;
 
 exports.flatMap = flatMap;
 exports.join = join;
@@ -16,7 +16,7 @@ exports.join = join;
  * @returns {Stream} new stream containing all events from each stream returned by f
  */
 function flatMap(f, stream) {
-	return join(map(f, stream));
+	return mergeMapConcurrently(f, Infinity, stream);
 }
 
 /**

--- a/lib/combinator/mergeConcurrently.js
+++ b/lib/combinator/mergeConcurrently.js
@@ -7,21 +7,32 @@ var dispose = require('../disposable/dispose');
 var LinkedList = require('../LinkedList');
 
 exports.mergeConcurrently = mergeConcurrently;
+exports.mergeMapConcurrently = mergeMapConcurrently;
 
-function mergeConcurrently(concurrency, stream) {
-	return new Stream(new MergeConcurrently(concurrency, stream.source));
+function id(x) {
+	return x;
 }
 
-function MergeConcurrently(concurrency, source) {
+function mergeConcurrently(concurrency, stream) {
+	return mergeMapConcurrently(function(x) { return x }, concurrency, stream);
+}
+
+function mergeMapConcurrently(f, concurrency, stream) {
+	return new Stream(new MergeConcurrently(f, concurrency, stream.source));
+}
+
+function MergeConcurrently(f, concurrency, source) {
+	this.f = f;
 	this.concurrency = concurrency;
 	this.source = source;
 }
 
 MergeConcurrently.prototype.run = function(sink, scheduler) {
-	return new Outer(this.concurrency, this.source, sink, scheduler);
+	return new Outer(this.f, this.concurrency, this.source, sink, scheduler);
 };
 
-function Outer(concurrency, source, sink, scheduler) {
+function Outer(f, concurrency, source, sink, scheduler) {
+	this.f = f;
 	this.concurrency = concurrency;
 	this.sink = sink;
 	this.scheduler = scheduler;
@@ -46,8 +57,12 @@ Outer.prototype._addInner = function(t, stream) {
 Outer.prototype._startInner = function(t, stream) {
 	var innerSink = new Inner(t, this, this.sink);
 	this.current.add(innerSink);
-	innerSink.disposable = stream.source.run(innerSink, this.scheduler);
+	innerSink.disposable = mapAndRun(this.f, innerSink, this.scheduler, stream);
 };
+
+function mapAndRun(f, innerSink, scheduler, stream) {
+	return f(stream).source.run(innerSink, scheduler);
+}
 
 Outer.prototype.end = function(t, x) {
 	this.active = false;

--- a/lib/combinator/mergeConcurrently.js
+++ b/lib/combinator/mergeConcurrently.js
@@ -5,16 +5,13 @@
 var Stream = require('../Stream');
 var dispose = require('../disposable/dispose');
 var LinkedList = require('../LinkedList');
+var identity = require('../base').identity;
 
 exports.mergeConcurrently = mergeConcurrently;
 exports.mergeMapConcurrently = mergeMapConcurrently;
 
-function id(x) {
-	return x;
-}
-
 function mergeConcurrently(concurrency, stream) {
-	return mergeMapConcurrently(function(x) { return x }, concurrency, stream);
+	return mergeMapConcurrently(identity, concurrency, stream);
 }
 
 function mergeMapConcurrently(f, concurrency, stream) {

--- a/test/combinator/concatMap-test.js
+++ b/test/combinator/concatMap-test.js
@@ -55,6 +55,23 @@ describe('concatMap', function() {
 			});
 	});
 
+	it('should map lazily', function() {
+		var s1 = te.atTimes([{ time: 0, value: 0 }, { time: 1, value: 1 }]);
+
+		var env = te.ticks(4);
+		var s = concatMap.concatMap(function(x) {
+			return te.atTimes([{ time: 2, value: env.scheduler.now() }]);
+		}, s1)
+
+		return te.collectEvents(s, env)
+			.then(function(events) {
+				expect(events).toEqual([
+					{ time: 2, value: 0 },
+					{ time: 4, value: 2 }
+				]);
+			});
+	})
+
 	it('should dispose outer stream', function() {
 		var dispose = this.spy();
 		var inner = streamOf(sentinel);


### PR DESCRIPTION
:warning: Experiment :warning:

Add `mergeMapConcurrently`, which lazily maps and merges.  Convert `concatMap` to use it, which allows `concatMap` to be lazy.

While the end result is *almost* indistinguishable from eager `concatMap`, it does change when the mapping function is called, which can change the timing of I/O, etc.  See the example in #217.  It eagerly fetches all of the items in parallel with the current eager `concatMap`, but fetches them in a non-overlapping sequence when `concatMap` is lazy.