### PR TITLE
Fix race condition in swtich test

### DIFF
--- a/test/switch-test.js
+++ b/test/switch-test.js
@@ -60,7 +60,7 @@ describe('switch', function() {
 			var i = 0;
 			var s = map(function() {
 				return constant(++i, periodic(10));
-			}, periodic(25));
+			}, periodic(27));
 
 			return sequenceEqual([1,1,1,2,2,2,3,3,3,4], take(10, switchLatest(s)));
 		});


### PR DESCRIPTION
This test fails one of 10 cases
```
Failure: switch | when input contains many streams | should switch when new stream arrives
  [expect.toEqual] [1, 1, 1, 2, 2, 3, 3, 3, 4, 4] expected to be equal to [1, 1, 1, 2, 2, 2, 3, 3, 3, 4]
```
On 50th ms both streems based on periodic(10) and periodic(25) triggers, and it happens on 5th element of resulting array
So change 25 to 27 will fix it for first 10 elements