### PR TITLE
Fix most.scan example

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -639,7 +639,7 @@ var numbers = most.iterate(function(x) {
 // [2,3,4]
 // ... etc ...
 numbers.scan(function(slidingWindow, x) {
-	return slidingWindow.concat(x).slice(-10);
+	return slidingWindow.concat(x).slice(-3);
 }, [])
 	.forEach(console.log.bind(console));
 ```


### PR DESCRIPTION
The description says: `Maintain a sliding window of (up to) 3 values in an array` and not 10