### PR TITLE
Fix build script warnings for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "eslint . && buster-test",
-    "build": "webpack --output-library most --output-library-target umd ./most.js --output-file dist/most.js && uglifyjs dist/most.js -c 'warnings=false' -m -o dist/most.min.js",
+    "build": "webpack --output-library most --output-library-target umd ./most.js --output-file dist/most.js && uglifyjs dist/most.js -c \"warnings=false\" -m -o dist/most.min.js",
     "preversion": "npm run build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^1.10.3",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",
-    "webpack": "^1.10.1"
+    "webpack": "^1.12.14"
   },
   "dependencies": {
     "@most/multicast": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "test": "eslint . && buster-test",
-    "build": "webpack --output-library most --output-library-target umd ./most.js --output-file dist/most.js && uglifyjs dist/most.js -c \"warnings=false\" -m -o dist/most.min.js",
+    "build": "webpack --output-library most --output-library-target umd ./most.js --output-filename dist/most.js && uglifyjs dist/most.js -c \"warnings=false\" -m -o dist/most.min.js",
     "preversion": "npm run build"
   },
   "repository": {


### PR DESCRIPTION
Got some messages while runing `npm run build` on windows

1. `Error parsing arguments for flag 'c': 'warnings=false'`  
Windows may use only double quotes in cmd, and unix can use both. So changing to double will make both happy

2. `output.file will be deprecated: Use 'output.filename' instead`  
Used webpack v1.12.14, pretty obvious message
