### PR TITLE
Improve switch perf

### DIFF
--- a/lib/combinator/switch.js
+++ b/lib/combinator/switch.js
@@ -3,10 +3,7 @@
 /** @author John Hann */
 
 var Stream = require('../Stream');
-var MulticastSource = require('@most/multicast').MulticastSource;
-var until = require('./timeslice').takeUntil;
-var mergeConcurrently = require('./mergeConcurrently').mergeConcurrently;
-var map = require('./transform').map;
+var dispose = require('../disposable/dispose')
 
 exports.switch = switchLatest;
 
@@ -17,11 +14,97 @@ exports.switch = switchLatest;
  * @returns {Stream} switching stream
  */
 function switchLatest(stream) {
-	var upstream = new Stream(new MulticastSource(stream.source));
-
-	return mergeConcurrently(1, map(untilNext, upstream));
-
-	function untilNext(s) {
-		return until(upstream, s);
-	}
+	return new Stream(new Switch(stream.source));
 }
+
+function Switch(source) {
+	this.source = source;
+}
+
+Switch.prototype.run = function(sink, scheduler) {
+	var switchSink = new SwitchSink(sink, scheduler);
+	return dispose.all(switchSink, this.source.run(switchSink, scheduler));
+};
+
+function SwitchSink(sink, scheduler) {
+	this.sink = sink;
+	this.scheduler = scheduler;
+	this.current = null;
+	this.ended = false;
+}
+
+SwitchSink.prototype.event = function(t, stream) {
+	this._disposeCurrent(t); // TODO: capture the result of this dispose
+	this.current = new Segment(t, Infinity, this, this.sink);
+	this.current.disposable = stream.source.run(this.current, this.scheduler);
+};
+
+SwitchSink.prototype.end = function(t, x) {
+	this.ended = true;
+	this._checkEnd(t, x);
+};
+
+SwitchSink.prototype.error = function(t, e) {
+	this.ended = true;
+	this.sink.error(t, e);
+};
+
+SwitchSink.prototype.dispose = function() {
+	return this._disposeCurrent(0);
+};
+
+SwitchSink.prototype._disposeCurrent = function(t) {
+	if(this.current !== null) {
+		return this.current._dispose(t);
+	}
+};
+
+SwitchSink.prototype._disposeInner = function(t, inner) {
+	inner._dispose(t); // TODO: capture the result of this dispose
+	if(inner === this.current) {
+		this.current = null;
+	}
+};
+
+SwitchSink.prototype._checkEnd = function(t, x) {
+	if(this.ended && this.current === null) {
+		this.sink.end(t, x);
+	}
+};
+
+SwitchSink.prototype._endInner = function(t, x, inner) {
+	this._disposeInner(t, inner);
+	this._checkEnd(t, x);
+};
+
+SwitchSink.prototype._errorInner = function(t, e, inner) {
+	this._disposeInner(t, inner);
+	this.sink.error(t, e);
+};
+
+function Segment(min, max, outer, sink) {
+	this.min = min;
+	this.max = max;
+	this.outer = outer;
+	this.sink = sink;
+	this.disposable = dispose.empty();
+}
+
+Segment.prototype.event = function(t, x) {
+	if(t < this.max) {
+		this.sink.event(Math.max(t, this.min), x);
+	}
+};
+
+Segment.prototype.end = function(t, x) {
+	this.outer._endInner(Math.max(t, this.min), x, this);
+};
+
+Segment.prototype.error = function(t, e) {
+	this.outer._errorInner(Math.max(t, this.min), e, this);
+};
+
+Segment.prototype._dispose = function(t) {
+	this.max = t;
+	dispose.tryDispose(t, this.disposable, this.sink)
+};

--- a/test/perf/switch.js
+++ b/test/perf/switch.js
@@ -1,0 +1,78 @@
+var Benchmark = require('benchmark');
+var most = require('../../most');
+var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
+var kefir = require('kefir');
+var bacon = require('baconjs');
+var lodash = require('lodash');
+var highland = require('highland');
+
+var runners = require('./runners');
+var kefirFromArray = runners.kefirFromArray;
+
+// Switching n streams, each containing m items.
+// Because this creates streams from arrays, it ends up
+// behaving like concatMap, but gives a sense of the
+// relative overhead introduced by each lib's switching
+// combinator.
+var mn = runners.getIntArg2(10000, 1000);
+var a = build(mn[0], mn[1]);
+
+function build(m, n) {
+  var a = new Array(n);
+  for(var i = 0; i< a.length; ++i) {
+    a[i] = buildArray(i*1000, m);
+  }
+  return a;
+}
+
+function buildArray(base, n) {
+  var a = new Array(n);
+  for(var i = 0; i< a.length; ++i) {
+    a[i] = base + i;
+  }
+  return a;
+}
+
+var suite = Benchmark.Suite('switch ' + mn[0] + ' x ' + mn[1] + ' streams');
+var options = {
+  defer: true,
+  onError: function(e) {
+    e.currentTarget.failure = e.error;
+  }
+};
+
+suite
+  .add('most', function(deferred) {
+    runners.runMost(deferred, most.from(a).map(most.from).switch().reduce(sum, 0));
+  }, options)
+  .add('rx 5', function(deferred) {
+    runners.runRx5(deferred,
+      rxjs.Observable.from(a).switchMap(
+        function(x) {return rxjs.Observable.from(x)}).reduce(sum, 0))
+  }, options)
+  .add('rx 4', function(deferred) {
+    runners.runRx(deferred,
+      rx.Observable.fromArray(a).flatMapLatest(
+        function(x) {return rx.Observable.fromArray(x)}).reduce(sum, 0));
+  }, options)
+  .add('kefir', function(deferred) {
+    runners.runKefir(deferred, kefirFromArray(a).flatMapLatest(kefirFromArray).scan(sum, 0).last());
+  }, options)
+  .add('bacon', function(deferred) {
+    runners.runBacon(deferred, bacon.fromArray(a).flatMapLatest(bacon.fromArray).reduce(0, sum));
+  }, options);
+
+runners.runSuite(suite);
+
+function sum(x, y) {
+  return x + y;
+}
+
+function even(x) {
+  return x % 2 === 0;
+}
+
+function identity(x) {
+  return x;
+}


### PR DESCRIPTION
This PR returns to a custom impl for `switch` to increase perf substantially.  Switch is a common and useful combinator, so the extra code here seems worthwhile.

The simplified impl in master is pleasing and intuitive, but uses *two* of our biggest perf hits: `multicast`, and  `mergeConcurrently`.  Given that, it performs admirably, but this custom impl annihilates it :)

#### Perf comparison

Custom impl:

```
switch 100000 x 1000 streams
-------------------------------------------------------
most               1156.98 op/s ±  0.96%   (82 samples)
```

Master:

```
switch 100000 x 1000 streams
-------------------------------------------------------
most                 56.04 op/s ±  7.22%   (65 samples)
```

#### Size comparison

Custom impl:

```
-rw-r--r--  1 brian  staff   11101 Apr 14 08:29 most.min.js.gz
```

Master:

```
-rw-r--r--  1 brian  staff   10933 Apr 14 08:30 most.min.js.gz
```