### PR TITLE
Ensure previous end events cannot disable recoverWith

### DIFF
--- a/lib/combinator/errors.js
+++ b/lib/combinator/errors.js
@@ -4,9 +4,11 @@
 
 var Stream = require('../Stream');
 var ValueSource = require('../source/ValueSource');
-var tryDispose = require('../disposable/dispose').tryDispose;
+var SafeSink = require('../sink/SafeSink');
+var Pipe = require('../sink/Pipe');
+var dispose = require('../disposable/dispose');
 var tryEvent = require('../source/tryEvent');
-var apply = require('../base').apply;
+var isPromise = require('../Promise').isPromise;
 
 exports.flatMapError = recoverWith;
 exports.recoverWith  = recoverWith;
@@ -47,39 +49,39 @@ RecoverWith.prototype.run = function(sink, scheduler) {
 
 function RecoverWithSink(f, source, sink, scheduler) {
 	this.f = f;
-	this.sink = sink;
+	this.sink = new SafeSink(sink);
 	this.scheduler = scheduler;
-	this.active = true;
 	this.disposable = source.run(this, scheduler);
 }
 
-RecoverWithSink.prototype.error = function(t, e) {
-	if(!this.active) {
-		return;
-	}
-
-	// TODO: forward dispose errors
-	tryDispose(t, this.disposable, this);
-
-	var stream = apply(this.f, e);
-	this.disposable = stream.source.run(this.sink, this.scheduler);
-};
-
 RecoverWithSink.prototype.event = function(t, x) {
-	if(!this.active) {
-		return;
-	}
-	tryEvent.tryEvent(t, x, this.sink);
-};
+		tryEvent.tryEvent(t, x, this.sink);
+}
 
 RecoverWithSink.prototype.end = function(t, x) {
-	if(!this.active) {
-		return;
-	}
-	tryEvent.tryEnd(t, x, this.sink);
+		tryEvent.tryEnd(t, x, this.sink);
+}
+
+RecoverWithSink.prototype.error = function(t, e) {
+	var nextSink = this.sink.disable();
+
+	var result = dispose.tryDispose(t, this.disposable, nextSink);
+	this.disposable = isPromise(result)
+		? dispose.promised(this._thenContinue(result, e, nextSink))
+		: this._continue(this.f, e, nextSink);
+};
+
+RecoverWithSink.prototype._thenContinue = function(p, x, sink) {
+	var self = this;
+	return p.then(function () {
+		return self._continue(self.f, x, sink);
+	});
+};
+
+RecoverWithSink.prototype._continue = function(f, x, sink) {
+	return f(x).source.run(sink, this.scheduler);
 };
 
 RecoverWithSink.prototype.dispose = function() {
-	this.active = false;
 	return this.disposable.dispose();
 };

--- a/lib/combinator/promises.js
+++ b/lib/combinator/promises.js
@@ -63,28 +63,28 @@ AwaitSink.prototype.event = function(t, promise) {
 	var self = this;
 	this.queue = this.queue.then(function() {
 		return self._event(promise);
-	}).catch(this._errorBound);
+	});
 };
 
 AwaitSink.prototype.end = function(t, x) {
 	var self = this;
 	this.queue = this.queue.then(function() {
 		return self._end(x);
-	}).catch(this._errorBound);
+	});
 };
 
 AwaitSink.prototype.error = function(t, e) {
 	var self = this;
 	// Don't resolve error values, propagate directly
 	this.queue = this.queue.then(function() {
-		return self._errorBound(e);
-	}).catch(fatal);
+		return self._errorBound(e).catch(fatal);
+	})
 };
 
 AwaitSink.prototype._event = function(promise) {
-	return promise.then(this._eventBound);
+	return promise.then(this._eventBound).catch(this._errorBound);
 };
 
 AwaitSink.prototype._end = function(x) {
-	return Promise.resolve(x).then(this._endBound);
+	return Promise.resolve(x).then(this._endBound).catch(this._errorBound);
 };

--- a/lib/combinator/promises.js
+++ b/lib/combinator/promises.js
@@ -63,28 +63,28 @@ AwaitSink.prototype.event = function(t, promise) {
 	var self = this;
 	this.queue = this.queue.then(function() {
 		return self._event(promise);
-	});
+	}).catch(this._errorBound);
 };
 
 AwaitSink.prototype.end = function(t, x) {
 	var self = this;
 	this.queue = this.queue.then(function() {
 		return self._end(x);
-	});
+	}).catch(this._errorBound);
 };
 
 AwaitSink.prototype.error = function(t, e) {
 	var self = this;
 	// Don't resolve error values, propagate directly
 	this.queue = this.queue.then(function() {
-		return self._errorBound(e).catch(fatal);
-	})
+		return self._errorBound(e);
+	}).catch(fatal);
 };
 
 AwaitSink.prototype._event = function(promise) {
-	return promise.then(this._eventBound).catch(this._errorBound);
+	return promise.then(this._eventBound);
 };
 
 AwaitSink.prototype._end = function(x) {
-	return Promise.resolve(x).then(this._endBound).catch(this._errorBound);
+	return Promise.resolve(x).then(this._endBound);
 };

--- a/lib/sink/SafeSink.js
+++ b/lib/sink/SafeSink.js
@@ -1,0 +1,35 @@
+/** @license MIT License (c) copyright 2010-2016 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+module.exports = SafeSink;
+
+function SafeSink(sink) {
+	this.sink = sink;
+	this.active = true;
+}
+
+SafeSink.prototype.event = function(t, x) {
+	if(!this.active) {
+		return;
+	}
+	this.sink.event(t, x);
+};
+
+SafeSink.prototype.end = function(t, x) {
+	if(!this.active) {
+		return;
+	}
+	this.disable();
+	this.sink.end(t, x);
+};
+
+SafeSink.prototype.error = function(t, e) {
+	this.disable();
+	this.sink.error(t, e);
+};
+
+SafeSink.prototype.disable = function() {
+	this.active = false;
+	return this.sink;
+}

--- a/test/combinator/promises-test.js
+++ b/test/combinator/promises-test.js
@@ -63,4 +63,14 @@ describe('fromPromise', function() {
 			});
 	});
 
+	it('should be recoverable if promise rejects', function() {
+		var s = promises.fromPromise(Promise.reject())
+			.recoverWith(function() {
+				return promises.fromPromise(Promise.resolve(sentinel));
+			});
+
+		return observe(function(x) {
+			expect(x).toBe(sentinel)
+		}, s);
+	})
 });

--- a/test/errors-test.js
+++ b/test/errors-test.js
@@ -37,7 +37,7 @@ describe('recoverWith', function() {
 
 	});
 
-	it('should recover from errors before recoverError', function() {
+	it('should recover from errors before recoverWith', function() {
 		var s = map(function() {
 			throw new Error();
 		}, just(other));
@@ -49,9 +49,8 @@ describe('recoverWith', function() {
 		}, s));
 	});
 
-	it('should not recover from errors after recoverError', function() {
-		var s = error.recoverWith(function() {
-			console.log('here');
+	it('should not recover from errors after recoverWith', function() {
+		var s = error.recoverWith(function(e) {
 			throw other;
 		}, just(123));
 

--- a/test/sink/SafeSink-test.js
+++ b/test/sink/SafeSink-test.js
@@ -1,0 +1,143 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var SafeSink = require('../../lib/sink/SafeSink');
+
+function testSink(event, end, error) {
+	return {
+		event: event,
+		end: end,
+		error: error
+	};
+}
+
+function testEvent(event) {
+	return testSink(event, fail, fail);
+}
+
+function testEnd(end) {
+	return testSink(fail, end, fail);
+}
+
+function testError(error) {
+	return testSink(fail, fail, error);
+}
+
+function fail() {
+	throw new Error('Should not be called')
+}
+
+function noop() {}
+
+describe('SafeSink', function() {
+	it('should propagate event while active', function() {
+		var time = 123
+		var expected = {}
+		var sink = new SafeSink(testEvent(function(t, x) {
+			expect(t).toBe(time);
+			expect(x).toBe(expected);
+		}));
+
+		sink.event(time, expected);
+	});
+
+	it('should propagate end while active', function() {
+		var time = 123
+		var expected = {}
+		var sink = new SafeSink(testEnd(function(t, x) {
+			expect(t).toBe(time);
+			expect(x).toBe(expected);
+		}));
+
+		sink.end(time, expected);
+	});
+
+	it('should propagate error while active', function() {
+		var time = 123
+		var expected = new Error()
+		var sink = new SafeSink(testError(function(t, x) {
+			expect(t).toBe(time);
+			expect(x).toBe(expected);
+		}));
+
+		sink.error(time, expected);
+	});
+
+	it('should not propagate event or end after end', function() {
+		var time = 123
+		var expected = {}
+		var sink = new SafeSink(testEnd(function(t, x) {
+			expect(t).toBe(time);
+			expect(x).toBe(expected);
+		}));
+
+		sink.end(time, expected);
+		sink.end(time+1, expected);
+		sink.event(time+2, expected);
+	});
+
+	it('should not propagate event or end after error', function() {
+		var time = 123
+		var expected = new Error()
+		var sink = new SafeSink(testError(function(t, x) {
+			expect(t).toBe(time);
+			expect(x).toBe(expected);
+		}));
+
+		sink.error(time, expected);
+		sink.end(time+1, expected);
+		sink.event(time+2, expected);
+	});;
+
+	it('should not propagate event or end after disabled', function() {
+		// Test will fail if any event, error, or end are
+		// propagated.  Buster requires at least one expectation
+		// per test, hence the expect(true) below
+		var sink = new SafeSink(testSink(fail, fail, fail));
+
+		sink.disable();
+		sink.end(1, {});
+		sink.event(2, {});
+		expect(true).toBe(true);
+	});
+
+	it('should propagate error after disable', function() {
+		var errorCalled = 0;
+		var sink = new SafeSink(testError(function() {
+			errorCalled += 1;
+		}));
+
+		sink.disable();
+		sink.error(1, new Error());
+		expect(errorCalled).toBe(1);
+	});
+
+	it('should propagate error after end', function() {
+		var errorCalled = 0;
+		var sink = new SafeSink(testSink(fail, noop, function() {
+			errorCalled += 1
+		}));
+
+		sink.end(0, {});
+		sink.error(1, new Error());
+		expect(errorCalled).toBe(1);
+	});
+
+	it('should propagate error after error', function() {
+		var errorCalled = 0;
+		var sink = new SafeSink(testSink(fail, noop, function() {
+			errorCalled += 1
+		}));
+
+		sink.error(0, new Error());
+		sink.error(1, new Error());
+		expect(errorCalled).toBe(2);
+	});
+
+	it('disable should return original sink', function() {
+		var original = testSink(fail, fail, fail);
+		var sink = new SafeSink(original);
+
+		expect(sink.disable()).toBe(original);
+	});
+})


### PR DESCRIPTION
Avoids timing issue when recovering--see included unit test.