### PR TITLE
Add slice fusion

### DIFF
--- a/lib/combinator/slice.js
+++ b/lib/combinator/slice.js
@@ -46,7 +46,7 @@ function slice(start, end, stream) {
 function sliceSource(start, end, source) {
 	if(source instanceof Slice) {
 		var s = start + source.skip;
-		var e = Math.min(s + end, s + source.take);
+		var e = Math.min(s + end, source.skip + source.take);
 		return new Slice(s, e, source.source);
 	}
 	return new Slice(start, end, source);

--- a/lib/combinator/slice.js
+++ b/lib/combinator/slice.js
@@ -40,7 +40,16 @@ function skip(n, stream) {
  */
 function slice(start, end, stream) {
 	return end <= start ? core.empty()
-		: new Stream(new Slice(start, end, stream.source));
+		: new Stream(sliceSource(start, end, stream.source));
+}
+
+function sliceSource(start, end, source) {
+	if(source instanceof Slice) {
+		var s = start + source.skip;
+		var e = Math.min(s + end, s + source.take);
+		return new Slice(s, e, source.source);
+	}
+	return new Slice(start, end, source);
 }
 
 function Slice(min, max, source) {

--- a/test/slice-test.js
+++ b/test/slice-test.js
@@ -6,6 +6,13 @@ var fromArray = require('../lib/source/fromArray').fromArray;
 var reduce = require('../lib/combinator/accumulate').reduce;
 
 describe('slice', function() {
+	it('should fuse adjacent take, skip, slice', function() {
+		var s = slice.skip(2, slice.slice(1, 10, slice.take(5, fromArray([1]))));
+		expect(s.source.skip).toBe(3);
+		expect(s.source.take).toBe(5);
+		expect(s.source.constructor).not.toBe(s.source.source.constructor);
+	});
+
 	it('should skip first n elements', function () {
 		var a = [1, 1, 1, 1, 1, 1, 1];
 		var s = slice.slice(2, a.length-2, fromArray(a));

--- a/test/slice-test.js
+++ b/test/slice-test.js
@@ -9,7 +9,7 @@ describe('slice', function() {
 	it('should fuse adjacent take, skip, slice', function() {
 		var s = slice.skip(2, slice.slice(1, 10, slice.take(5, fromArray([1]))));
 		expect(s.source.skip).toBe(3);
-		expect(s.source.take).toBe(5);
+		expect(s.source.take).toBe(2);
 		expect(s.source.constructor).not.toBe(s.source.source.constructor);
 	});
 

--- a/test/slice-test.js
+++ b/test/slice-test.js
@@ -6,22 +6,29 @@ var fromArray = require('../lib/source/fromArray').fromArray;
 var reduce = require('../lib/combinator/accumulate').reduce;
 
 describe('slice', function() {
-	it('should fuse adjacent take, skip, slice', function() {
-		var s = slice.skip(2, slice.slice(1, 10, slice.take(5, fromArray([1]))));
-		expect(s.source.skip).toBe(3);
-		expect(s.source.take).toBe(2);
-		expect(s.source.constructor).not.toBe(s.source.source.constructor);
+	describe('should narrow', function() {
+		it('when second slice is smaller', function() {
+			var s = slice.slice(1, 5, slice.slice(1, 10, fromArray([1])));
+			expect(s.source.skip).toBe(2);
+			expect(s.source.take).toBe(5);
+		});
+
+		it('when second slice is larger', function() {
+			var s = slice.slice(1, 10, slice.slice(1, 5, fromArray([1])));
+			expect(s.source.skip).toBe(2);
+			expect(s.source.take).toBe(3);
+		});
 	});
 
-	it('should skip first n elements', function () {
-		var a = [1, 1, 1, 1, 1, 1, 1];
+	it('should retain only sliced range', function () {
+		var a = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 		var s = slice.slice(2, a.length-2, fromArray(a));
 
-		return reduce(function (count) {
-			return count + 1;
-		}, 0, s)
-			.then(function (count) {
-				expect(count).toBe(a.length - 4);
+		return reduce(function (a, x) {
+			return a.concat(x);
+		}, [], s)
+			.then(function (result) {
+				expect(result).toEqual(a.slice(2, a.length-2))
 			});
 	});
 });


### PR DESCRIPTION
This fuses slice.slice to slice.  Because take and skip are both implemented as slice, it also fuses skip.take and take.skip to slice. This allows *any number* of adjacent take, skip, and slice to be fused into a single slice.

#### Todo

- [x] unit tests to verify that fusion math is correct (existing unit tests all still pass)