### PR TITLE
Improve slice perf

### DIFF
--- a/lib/combinator/slice.js
+++ b/lib/combinator/slice.js
@@ -45,26 +45,27 @@ function slice(start, end, stream) {
 
 function sliceSource(start, end, source) {
 	if(source instanceof Slice) {
-		var s = start + source.skip;
-		var e = Math.min(s + end, source.skip + source.take);
-		return new Slice(s, e, source.source);
+		start += source.min;
+		end = Math.min(end - source.min, source.max);
+		return new Slice(start, end, source.source);
 	}
 	return new Slice(start, end, source);
 }
 
 function Slice(min, max, source) {
-	this.skip = min;
-	this.take = max - min;
+	this.min = min;
+	this.max = max;
 	this.source = source;
 }
 
 Slice.prototype.run = function(sink, scheduler) {
-	return new SliceSink(this.skip, this.take, this.source, sink, scheduler);
+	return new SliceSink(this.min, this.max, this.source, sink, scheduler);
 };
 
-function SliceSink(skip, take, source, sink, scheduler) {
-	this.skip = skip;
-	this.take = take;
+function SliceSink(min, max, source, sink, scheduler) {
+	this.min = min;
+	this.max = max-1;
+	this.index = 0;
 	this.sink = sink;
 	this.disposable = dispose.once(source.run(this, scheduler));
 }
@@ -73,18 +74,15 @@ SliceSink.prototype.end   = Sink.prototype.end;
 SliceSink.prototype.error = Sink.prototype.error;
 
 SliceSink.prototype.event = function(t, x) {
-	if(this.skip > 0) {
-		this.skip -= 1;
+	var index = this.index;
+	this.index++;
+
+	if(index < this.min || index > this.max) {
 		return;
 	}
 
-	if(this.take === 0) {
-		return;
-	}
-
-	this.take -= 1;
 	this.sink.event(t, x);
-	if(this.take === 0) {
+	if(index === this.max) {
 		this.dispose();
 		this.sink.end(t, x);
 	}

--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -10,10 +10,12 @@
     "flatMap": "node ./flatMap.js",
     "merge": "node ./merge.js",
     "merge-nested": "node ./merge-nested.js",
+    "sample": "node ./sample.js",
     "scan": "node ./scan.js",
+    "slice": "node ./slice.js",
     "skipRepeats": "node ./skipRepeats.js",
     "zip": "node ./zip.js",
-    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run zip && npm run scan && npm run skipRepeats"
+    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run zip && npm run sample && npm run scan && npm run slice && npm run skipRepeats"
   },
   "dependencies": {
     "@reactivex/rxjs": "5.0.0-beta.4",

--- a/test/perf/slice.js
+++ b/test/perf/slice.js
@@ -1,0 +1,71 @@
+var Benchmark = require('benchmark');
+var most = require('../../most');
+var rx = require('rx');
+var rxjs = require('@reactivex/rxjs')
+var kefir = require('kefir');
+var bacon = require('baconjs');
+var lodash = require('lodash');
+var highland = require('highland');
+
+var runners = require('./runners');
+var kefirFromArray = runners.kefirFromArray;
+
+// Create a stream from an Array of n integers
+// filter out odds, map remaining evens by adding 1, then reduce by summing
+var n = runners.getIntArg(1000000);
+var a = new Array(n);
+for(var i = 0; i< a.length; ++i) {
+	a[i] = i;
+}
+
+var suite = Benchmark.Suite('skip(n/4) -> take(n/2) ' + n + ' integers');
+var options = {
+	defer: true,
+	onError: function(e) {
+		e.currentTarget.failure = e.error;
+	}
+};
+
+var s = n * 0.25;
+var t = n * 0.5;
+
+suite
+	.add('most', function(deferred) {
+		runners.runMost(deferred, most.from(a).skip(s).take(t).map(add1).reduce(sum, 0));
+	}, options)
+	.add('rx 4', function(deferred) {
+		runners.runRx(deferred, rx.Observable.fromArray(a).skip(s).take(t).reduce(sum, 0));
+	}, options)
+	.add('rx 5', function(deferred) {
+		runners.runRx5(deferred,
+			rxjs.Observable.from(a).skip(s).take(t).reduce(sum, 0));
+	}, options)
+	.add('kefir', function(deferred) {
+		runners.runKefir(deferred, kefirFromArray(a).skip(s).take(t).scan(sum, 0).last());
+	}, options)
+	.add('bacon', function(deferred) {
+		runners.runBacon(deferred, bacon.fromArray(a).skip(s).take(t).reduce(0, sum));
+	}, options)
+	.add('highland', function(deferred) {
+		runners.runHighland(deferred, highland(a).drop(s).take(t).reduce(0, sum));
+	}, options)
+	.add('lodash', function() {
+		return lodash(a).slice(s).slice(0, t).reduce(sum, 0);
+	})
+	.add('Array', function() {
+		return a.slice(s).slice(0, t).reduce(sum, 0);
+	});
+
+runners.runSuite(suite);
+
+function add1(x) {
+	return x + 1;
+}
+
+function even(x) {
+	return x % 2 === 0;
+}
+
+function sum(x, y) {
+	return x + y;
+}

--- a/test/slice-test.js
+++ b/test/slice-test.js
@@ -9,14 +9,14 @@ describe('slice', function() {
 	describe('should narrow', function() {
 		it('when second slice is smaller', function() {
 			var s = slice.slice(1, 5, slice.slice(1, 10, fromArray([1])));
-			expect(s.source.skip).toBe(2);
-			expect(s.source.take).toBe(5);
+			expect(s.source.min).toBe(2);
+			expect(s.source.max).toBe(4);
 		});
 
 		it('when second slice is larger', function() {
 			var s = slice.slice(1, 10, slice.slice(1, 5, fromArray([1])));
-			expect(s.source.skip).toBe(2);
-			expect(s.source.take).toBe(3);
+			expect(s.source.min).toBe(2);
+			expect(s.source.max).toBe(5);
 		});
 	});
 


### PR DESCRIPTION
The algorithm slice was using was definitely not optimization friendly.  The slice fusion *was* helping, but only about 25%.  By tweaking the algorithm, the fusion has a much larger effect now.  Using the included perf test ...

This PR:

```
skip(n/4) -> take(n/2) 1000000 integers
-------------------------------------------------------
most                498.39 op/s ±  0.79%   (82 samples)
```

master:

```
skip(n/4) -> take(n/2) 1000000 integers
-------------------------------------------------------
most                104.89 op/s ±  1.14%   (79 samples)
```

Once again, since take and skip are implemented using slice, all three operations will get the perf boost.