### PR TITLE
feat(Symbol.observable): adds symbol observable interop point

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@most/multicast": "^1.0.3",
-    "@most/prelude": "^1.1.0"
+    "@most/prelude": "^1.1.0",
+    "symbol-observable": "^0.2.4"
   }
 }

--- a/test/interop-test.js
+++ b/test/interop-test.js
@@ -1,0 +1,85 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+var $$observable = require('symbol-observable');
+
+var most = require('../most.js')
+
+var sentinel = { value: 'sentinel' };
+
+describe('Stream', function() {
+
+	it('should implement Symbol.observable', function (done) {
+    var isDisposed = false;
+    var results = [];
+
+		var stream = most.create(function (add, end, error) {
+      add(1);
+      add(2);
+      add(3);
+      end('done');
+      return function () {
+        isDisposed = true;
+      }
+    });
+
+
+    var observable = stream[$$observable]();
+
+    expect(typeof observable.subscribe).toBe('function');
+
+    var subscription = observable.subscribe({
+      next: function (value) {
+        results.push(value);
+      },
+      error: function (err) {
+        throw err;
+      },
+      complete: function (value) {
+        expect(results).toEqual([1, 2, 3]);
+        expect(value).toEqual('done');
+        expect(isDisposed).toBe(true);
+        done();
+      }
+    });
+
+    expect(typeof subscription.unsubscribe).toBe('function');
+	});
+
+  it('should return an observable that can be cancelled via unsubscription', function () {
+    var results = [];
+
+		var stream = most.create(function (add, end, error) {
+      var i = 0;
+      var id = setInterval(function () {
+        add(i++);
+        if (i === 3) {
+          end('done');
+        }
+      });
+
+      return function () {
+        clearInterval(id);
+        expect(results).toEqual([0]);
+        done();
+      }
+    });
+
+
+    var observable = stream[$$observable]();
+
+    expect(typeof observable.subscribe).toBe('function');
+
+    var subscription = observable.subscribe({
+      next: function (value) {
+        results.push(value);
+        subscription.unsubscribe();
+      },
+      error: function (err) {
+        throw err;
+      },
+      complete: function (value) {
+        throw new Error('should not complete');
+      }
+    });
+  });
+});


### PR DESCRIPTION
This will enable Most to interop with Kefir, RxJS and libraries like Redux

Related #160

@briancavalier a few things:

1. I'm basically *sure* that's not the right place for the code, so I'm not sure how you want to organize it.
2. It took some hackery to get the unsubscription semantic required by the ES observable.
3. I'm a little concerned about possible promise-error-trapping related weirdness here. Errors thrown well down an observable chain during `error` or `complete` handlers may be squelched, because they're wrapped in promise handlers.