### PR TITLE
add lazy.js to test/perf

### DIFF
--- a/test/perf/concatMap.js
+++ b/test/perf/concatMap.js
@@ -5,6 +5,7 @@ var rxjs = require('@reactivex/rxjs');
 var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
+var lazy = require('lazy.js')
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -63,6 +64,9 @@ suite
 	.add('lodash', function() {
 		return lodashConcatMap(identity, a).reduce(sum, 0);
 	})
+	.add('lazy', function() {
+		return lazyConcatMap(identity, a).reduce(sum, 0);
+	})
 	.add('Array', function() {
 		return arrayConcatMap(identity, a).reduce(sum, 0);
 	});
@@ -77,6 +81,10 @@ function arrayConcatMap(f, a) {
 
 function lodashConcatMap(f, a) {
 	return lodash(a).map(f).flatten();
+}
+
+function lazyConcatMap(f, a) {
+	return lazy(a).map(f).flatten();
 }
 
 function sum(x, y) {

--- a/test/perf/filter-map-reduce.js
+++ b/test/perf/filter-map-reduce.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -48,6 +49,9 @@ suite
 	}, options)
 	.add('lodash', function() {
 		return lodash(a).filter(even).map(add1).reduce(sum, 0);
+	})
+	.add('lazy', function() {
+		return lazy(a).filter(even).map(add1).reduce(sum, 0);
 	})
 	.add('Array', function() {
 		return a.filter(even).map(add1).reduce(sum, 0);

--- a/test/perf/flatMap.js
+++ b/test/perf/flatMap.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -65,6 +66,9 @@ suite
 	.add('lodash', function() {
 		return lodashFlatMap(identity, a).reduce(sum, 0);
 	})
+	.add('lazy', function() {
+		return lazyFlatMap(identity, a).reduce(sum, 0);
+	})
 	.add('Array', function() {
 		return arrayFlatMap(identity, a).reduce(sum, 0);
 	});
@@ -79,6 +83,10 @@ function arrayFlatMap(f, a) {
 
 function lodashFlatMap(f, a) {
 	return lodash(a).map(f).flatten();
+}
+
+function lazyFlatMap(f, a) {
+	return lazy(a).map(f).flatten();
 }
 
 function sum(x, y) {

--- a/test/perf/merge.js
+++ b/test/perf/merge.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -73,6 +74,10 @@ suite
 	.add('lodash', function() {
 		// "Merge" synchronous arrays by concatenation
 		return lodash(a).flatten().reduce(sum, 0);
+	})
+	.add('lazy', function() {
+		// "Merge" synchronous arrays by concatenation
+		return lazy(a).flatten().reduce(sum, 0);
 	})
 	.add('Array', function() {
 		// "Merge" synchronous arrays by concatenation

--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -21,6 +21,7 @@
     "benchmark": "github:bestiejs/benchmark.js#master",
     "highland": "^2.5.1",
     "kefir": "^3.2.0",
+    "lazy.js": "^0.4.2",
     "lodash": "^3.10.1",
     "rx": "^4.0.7"
   }

--- a/test/perf/scan.js
+++ b/test/perf/scan.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -48,6 +49,9 @@ suite
 	.add('lodash', function() {
 		return lodashScan(sum, 0, a).reduce(passthrough, 0);
 	})
+	.add('lazy', function() {
+		return lazyScan(sum, 0, a).reduce(passthrough, 0);
+	})
 	.add('Array', function() {
 		return arrayScan(sum, 0, a).reduce(passthrough, 0);
 	});
@@ -64,6 +68,13 @@ function arrayScan(f, initial, a) {
 function lodashScan(f, initial, a) {
 	var result = initial;
 	return lodash(a).map(function(x) {
+		return result = f(result, x);
+	});
+}
+
+function lazyScan(f, initial, a) {
+	var result = initial;
+	return lazy(a).map(function(x) {
 		return result = f(result, x);
 	});
 }

--- a/test/perf/skipRepeats.js
+++ b/test/perf/skipRepeats.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -44,6 +45,9 @@ suite
 	}, options)
 	.add('lodash', function() {
 		return lodash(a).uniq(true).reduce(sum, 0);
+	})
+	.add('lazy', function() {
+		return lazy(a).uniq().reduce(sum, 0);
 	})
 	.add('Array', function() {
 		return arrayUniq(a).reduce(sum, 0);

--- a/test/perf/zip.js
+++ b/test/perf/zip.js
@@ -6,6 +6,7 @@ var kefir = require('kefir');
 var bacon = require('baconjs');
 var lodash = require('lodash');
 var highland = require('highland');
+var lazy = require('lazy.js');
 
 var runners = require('./runners');
 var kefirFromArray = runners.kefirFromArray;
@@ -50,6 +51,9 @@ suite
 	}, options)
 	.add('lodash', function() {
 		return lodash(a).zip(b).map(addPair).reduce(add, 0);
+	})
+	.add('lazy', function() {
+		return lazy(a).zip(b).map(addPair).reduce(add, 0);
 	});
 
 runners.runSuite(suite);


### PR DESCRIPTION
Hey,

Got myself tinkering with this and decide to add lazy.js to test/perf, most of the time 2nd to ```most```, but it beat it 4x in ```zip 2 x 100000 integers``` test. I didn't update the readme since I'm running node v5.7.1.