### PR TITLE
Test documentation with markdown-doctest

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,5 +1,4 @@
 var most = require(__dirname);
-var jsdom = require('jsdom');
 var path = require('path');
 var fs = require('fs');
 
@@ -13,20 +12,6 @@ if (fs.existsSync(path.join(__dirname, '/node_modules/babel'))) {
 // needed for regeneratorRuntime
 require(path.join(__dirname, babelPath, 'polyfill'));
 
-var html = [
-  '<head></head>',
-  '<body>',
-    '<form></form>',
-    '<div class="the-button"></div>',
-    '<div class="button"></div>',
-    '<div class="container"></div>',
-    '<input class="x">',
-    '<input class="y">',
-    '<input name="search-text">',
-    '<div class="result">',
-  '</body>'
-].join('\n');
-
 function noop () {};
 
 module.exports = {
@@ -36,8 +21,21 @@ module.exports = {
 
   globals: {
     most: most,
+
     regeneratorRuntime: regeneratorRuntime,
-    document: jsdom.jsdom(html),
+
+    document: {
+      addEventListener: noop,
+      removeEventListener: noop,
+
+      querySelector: function () {
+        return {
+          addEventListener: noop,
+          removeEventListener: noop
+        }
+      }
+    },
+
     exports: {},
 
     doSomething: noop,

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,0 +1,49 @@
+var most = require('.');
+var when = require('when');
+var rest = require('rest');
+var jsdom = require('jsdom');
+
+var foo = require(__dirname + "/node_modules/markdown-doctest/node_modules/babel/polyfill");
+
+var html = [
+  '<head></head>',
+  '<body>',
+    '<form></form>',
+    '<div class="the-button"></div>',
+    '<div class="button"></div>',
+    '<div class="container"></div>',
+    '<input class="x">',
+    '<input class="y">',
+    '<input name="search-text">',
+    '<div class="result">',
+  '</body>'
+].join('\n');
+
+function noop () {};
+
+module.exports = {
+  require: {
+    'most': most,
+    'when': when,
+    'rest': rest
+  },
+
+  globals: {
+    most: most,
+    regeneratorRuntime: regeneratorRuntime,
+    document: jsdom.jsdom(html),
+    exports: {},
+
+    doSomething: noop,
+    parseForm: noop,
+    postToServer: noop,
+    processData: noop,
+
+    stream: most.empty(),
+    mousemovesAfterFirstClick: most.empty()
+  },
+
+  babel: {
+    stage: 0
+  }
+}

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,7 +1,17 @@
-var most = require('.');
+var most = require(__dirname);
 var jsdom = require('jsdom');
+var path = require('path');
+var fs = require('fs');
 
-require(__dirname + "/node_modules/markdown-doctest/node_modules/babel/polyfill");
+// because npm 3 flattens modules
+if (fs.existsSync(path.join(__dirname, '/node_modules/babel'))) {
+  var babelPath = '/node_modules/babel';
+} else {
+  var babelPath = '/node_modules/markdown-doctest/node_modules/babel';
+}
+
+// needed for regeneratorRuntime
+require(path.join(__dirname, babelPath, 'polyfill'));
 
 var html = [
   '<head></head>',

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -16,7 +16,8 @@ function noop () {};
 
 module.exports = {
   require: {
-    most: most
+    most: most,
+   'transducers-js': require('transducers-js')
   },
 
   globals: {

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,9 +1,7 @@
 var most = require('.');
-var when = require('when');
-var rest = require('rest');
 var jsdom = require('jsdom');
 
-var foo = require(__dirname + "/node_modules/markdown-doctest/node_modules/babel/polyfill");
+require(__dirname + "/node_modules/markdown-doctest/node_modules/babel/polyfill");
 
 var html = [
   '<head></head>',
@@ -23,9 +21,7 @@ function noop () {};
 
 module.exports = {
   require: {
-    'most': most,
-    'when': when,
-    'rest': rest
+    most: most
   },
 
   globals: {

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,7 +227,6 @@ Create a stream that contains no events and never ends.
 
 Build an infinite stream by computing successive items iteratively.  Conceptually, the stream will contain: `[initial, f(initial), f(f(initial)), ...]`
 
-<!-- skip-example -->
 ```js
 // An infinite stream of all integers >= 0, ie
 // 0, 1, 2, 3, 4, 5, ...
@@ -238,7 +237,6 @@ most.iterate(function(x) {
 
 The iterating function may return a promise.  This allows `most.iterate` to be used to build asynchronous streams of future values.  For example:
 
-<!-- skip-example -->
 ```js
 var when = require('when');
 // An infinite stream of all integers >= 0, each delayed by 1 more
@@ -539,6 +537,7 @@ stream.recoverWith(f): -a-b-c-d-e-f->
 
 When a stream fails with an error, the error will be passed to `f`.  `f` must return a new stream to replace the error.
 
+<!-- skip-example -->
 ```js
 var rest = require('rest');
 
@@ -633,6 +632,7 @@ most.from(['a', 'b', 'c', 'd'])
 	.forEach(console.log.bind(console));
 ```
 
+<!-- skip-example -->
 ```js
 // Maintain a sliding window of (up to) 3 values in an array
 
@@ -675,6 +675,7 @@ stream.chain(f):   -1--2-13---2-1-233|
 
 Note the difference between [`concatMap`](#concatmap) and [`chain`](#chain): `concatMap` concatenates, while `chain` merges.
 
+<!-- skip-example -->
 ```js
 // Logs: 1 2 1 1 2 1 1 2 2 2
 most.from([1, 2])
@@ -701,6 +702,7 @@ stream.continueWith(f): -a-b-c-d-1-2-3-4-5->
 ```
 
 
+<!-- skip-example -->
 ```js
 most.periodic(1000, 'x')
     .take(4)
@@ -735,6 +737,7 @@ f called lazily:      ^      ^          ^
 
 Note the difference between [`concatMap`](#concatmap) and [`flatMap`](#flatmap): `concatMap` concatenates, while `flatMap` merges.
 
+<!-- skip-example -->
 ```js
 // Logs: 1 1 1 1 1 2 2 2 2 2
 most.from([1, 2])

--- a/docs/api.md
+++ b/docs/api.md
@@ -227,6 +227,7 @@ Create a stream that contains no events and never ends.
 
 Build an infinite stream by computing successive items iteratively.  Conceptually, the stream will contain: `[initial, f(initial), f(f(initial)), ...]`
 
+<!-- skip-example -->
 ```js
 // An infinite stream of all integers >= 0, ie
 // 0, 1, 2, 3, 4, 5, ...
@@ -237,6 +238,7 @@ most.iterate(function(x) {
 
 The iterating function may return a promise.  This allows `most.iterate` to be used to build asynchronous streams of future values.  For example:
 
+<!-- skip-example -->
 ```js
 var when = require('when');
 // An infinite stream of all integers >= 0, each delayed by 1 more
@@ -340,7 +342,7 @@ var clicks = most.fromEvent('click', document.querySelector('.the-button'));
 // in conjunction with e.target.matches this will allow only events with
 // .the-button class to be processed
 var container = document.querySelector('.container');
-most.fromEvent('click', container);
+most.fromEvent('click', container)
 	.filter(function(e){
     	return e.target.matches('.the-button');
 	})
@@ -402,6 +404,7 @@ The publisher function can use `add`, `end`, and `error`:
 
 * Pulling the `add`, `end`, and/or `error` functions out of the publisher closure is *not supported*.
 
+<!-- skip-example -->
 ```js
 // Unsupported:
 let emitEvent, emitEnd, emitError
@@ -479,6 +482,7 @@ stream
 
 Create a new stream containing `x` followed by all events in `stream`.
 
+<!-- skip-example -->
 ```js
 stream:              a-b-c-d->
 stream.startWith(x): xa-b-c-d->
@@ -491,6 +495,7 @@ stream.startWith(x): xa-b-c-d->
 
 Create a new stream containing all events in `stream1` followed by all events in `stream2`.
 
+<!-- skip-example -->
 ```js
 stream1:                 -a-b-c|
 stream2:                 -d-e-f->
@@ -555,6 +560,7 @@ stream.map(JSON.parse)
 
 Create a stream in the error state.  This can be useful for functions that need to return a stream, but need to signal an error.
 
+<!-- skip-example -->
 ```js
 most.throwError(X): X
 ```
@@ -844,6 +850,7 @@ Create a new stream by passing items through the provided transducer.
 Most.js supports any transducer that implements the *de facto* JavaScript transducer protocol.  For example, two popular transducers libraries are [transducers-js](https://github.com/cognitect-labs/transducers-js) and [transducers.js](https://github.com/jlongster/transducers.js).
 
 
+<!-- skip-example -->
 ```js
 // Create a transducer that slices, filters, and maps
 var transducers = require('transducers-js');
@@ -986,7 +993,7 @@ If `startSignal` is empty or never emits an event, then the returned stream will
 ```js
 // Start logging mouse events when the user clicks.
 most.fromEvent('mousemove', document)
-	.since(most.fromEvent('click', document)
+	.since(most.fromEvent('click', document))
 	.forEach(console.log.bind(console));
 ```
 
@@ -1252,7 +1259,7 @@ var click = most.fromEvent('click', document.querySelector('.button'));
 var resultStream = click.sample(add, xStream, yStream);
 
 var resultNode = document.querySelector('.result');
-result.observe(function(z) {
+resultStream.observe(function(z) {
 	resultNode.textContent = z;
 });
 ```
@@ -1411,6 +1418,7 @@ stream:         -p---q---r->
 stream.await(): ---1--X
 ```
 
+<!-- skip-example -->
 ```js
 var urls = [url1, url2, url3, ...];
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -855,7 +855,6 @@ Create a new stream by passing items through the provided transducer.
 Most.js supports any transducer that implements the *de facto* JavaScript transducer protocol.  For example, two popular transducers libraries are [transducers-js](https://github.com/cognitect-labs/transducers-js) and [transducers.js](https://github.com/jlongster/transducers.js).
 
 
-<!-- skip-example -->
 ```js
 // Create a transducer that slices, filters, and maps
 var transducers = require('transducers-js');

--- a/docs/api.md
+++ b/docs/api.md
@@ -237,6 +237,7 @@ most.iterate(function(x) {
 
 The iterating function may return a promise.  This allows `most.iterate` to be used to build asynchronous streams of future values.  For example:
 
+<!-- skip-example -->
 ```js
 var when = require('when');
 // An infinite stream of all integers >= 0, each delayed by 1 more
@@ -269,6 +270,7 @@ The unfolding function accepts a seed value and must return a tuple: `{value:*, 
 
 Note that if the unfolding function never returns a tuple with `tuple.done == true`, the stream will be infinite.
 
+<!-- skip-example -->
 ```js
 var rest = require('rest');
 var urlPrefix = 'product/';

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -4,6 +4,7 @@
 
 Consider the following statement:
 
+<!-- skip-example -->
 ```js
 var x = a + b;
 ```

--- a/docs/recipes/event-delegation.md
+++ b/docs/recipes/event-delegation.md
@@ -28,6 +28,7 @@ most.fromEvent('click', container)
     });
 ```
 
+<!-- skip-example -->
 ```js
 var $ = require('jquery');
 var container = $(".parent");

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "buster": "~0.7",
     "eslint": "^1.10.3",
-    "jsdom": "^8.4.0",
+    "jsdom": "^3.1.2",
     "markdown-doctest": "^0.3.3",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,9 @@
     "eslint": "^1.10.3",
     "jsdom": "^8.4.0",
     "markdown-doctest": "^0.3.3",
-    "rest": "^1.3.2",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",
-    "webpack": "^1.12.14",
-    "when": "^3.7.7"
+    "webpack": "^1.12.14"
   },
   "dependencies": {
     "@most/multicast": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "lib/**/*.js"
   ],
   "scripts": {
-    "test": "eslint . && buster-test",
+    "test": "eslint . && buster-test && npm run doctest",
     "build": "webpack --output-library most --output-library-target umd ./most.js --output-filename dist/most.js && uglifyjs dist/most.js -c \"warnings=false\" -m -o dist/most.min.js",
-    "preversion": "npm run build"
+    "preversion": "npm run build",
+    "doctest": "markdown-doctest"
   },
   "repository": {
     "type": "git",
@@ -39,9 +40,13 @@
   "devDependencies": {
     "buster": "~0.7",
     "eslint": "^1.10.3",
+    "jsdom": "^8.4.0",
+    "markdown-doctest": "^0.3.3",
+    "rest": "^1.3.2",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",
-    "webpack": "^1.12.14"
+    "webpack": "^1.12.14",
+    "when": "^3.7.7"
   },
   "dependencies": {
     "@most/multicast": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   "devDependencies": {
     "buster": "~0.7",
     "eslint": "^1.10.3",
-    "jsdom": "^3.1.2",
     "markdown-doctest": "^0.3.3",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "buster": "~0.7",
     "eslint": "^1.10.3",
-    "markdown-doctest": "^0.3.3",
+    "markdown-doctest": "^0.3.4",
     "transducers-js": "^0.4.174",
     "uglify-js": "^2.4.23",
     "webpack": "^1.12.14"


### PR DESCRIPTION
Hello!

I'm the author of [markdown-doctest](https://github.com/Widdershin/markdown-doctest), a tool for automatically testing that documentation examples are runnable. The idea is that it runs as part of the CI process so that new documentation doesn't add any faults and if any breaking changes are made it's clear.

I've integrated it with most, and as part of that I fixed a few typos in the documentation. 

markdown-doctest is currently used with RxJS and xstream, among other libraries.

I've set it up here so that it runs after the test suite when you run `npm test`. It's also possible to set it up so that it only runs on CI.

Let me know what you think.