### PR TITLE
Add throttle fusion and map-throttle commutation

### DIFF
--- a/lib/combinator/limit.js
+++ b/lib/combinator/limit.js
@@ -6,6 +6,7 @@ var Stream = require('../Stream');
 var Sink = require('../sink/Pipe');
 var dispose = require('../disposable/dispose');
 var PropagateTask = require('../scheduler/PropagateTask');
+var Map = require('../fusion/Map');
 
 exports.throttle = throttle;
 exports.debounce = debounce;
@@ -17,7 +18,21 @@ exports.debounce = debounce;
  * @returns {Stream}
  */
 function throttle(period, stream) {
-	return new Stream(new Throttle(period, stream.source));
+	return new Stream(throttleSource(period, stream.source));
+}
+
+function throttleSource(period, source) {
+	return source instanceof Map ? commuteMapThrottle(period, source)
+		: source instanceof Throttle ? fuseThrottle(period, source)
+		: new Throttle(period, source)
+}
+
+function commuteMapThrottle(period, source) {
+	return Map.create(source.f, throttleSource(period, source.source))
+}
+
+function fuseThrottle(period, source) {
+	return new Throttle(Math.max(period, source.period), source.source)
 }
 
 function Throttle(period, source) {

--- a/lib/combinator/limit.js
+++ b/lib/combinator/limit.js
@@ -36,23 +36,23 @@ function fuseThrottle(period, source) {
 }
 
 function Throttle(period, source) {
-	this.dt = period;
+	this.period = period;
 	this.source = source;
 }
 
 Throttle.prototype.run = function(sink, scheduler) {
-	return this.source.run(new ThrottleSink(this.dt, sink), scheduler);
+	return this.source.run(new ThrottleSink(this.period, sink), scheduler);
 };
 
-function ThrottleSink(dt, sink) {
+function ThrottleSink(period, sink) {
 	this.time = 0;
-	this.dt = dt;
+	this.period = period;
 	this.sink = sink;
 }
 
 ThrottleSink.prototype.event = function(t, x) {
 	if(t >= this.time) {
-		this.time = t + this.dt;
+		this.time = t + this.period;
 		this.sink.event(t, x);
 	}
 };

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -103,6 +103,15 @@ describe('debounce', function() {
 });
 
 describe('throttle', function() {
+	describe('fusion', function() {
+		it('should use max', function() {
+			var s1 = limit.throttle(2, limit.throttle(1, te.atTimes([])));
+			var s2 = limit.throttle(1, limit.throttle(2, te.atTimes([])));
+			expect(s1.source.period).toBe(s2.source.period);
+			expect(s1.source.period).toBe(2);
+		});
+	});
+
 	it('should exclude items that are too frequent', function() {
 		var s = te.atTimes([
 			{ time: 0, value: 0 },

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -14,6 +14,7 @@ var take = require('../lib/combinator/slice').take;
 var observe = require('../lib/combinator/observe').observe;
 var fromArray = require('../lib/source/fromArray').fromArray;
 var core = require('../lib/source/core');
+var Map = require('../lib/fusion/Map');
 
 var empty = core.empty;
 var streamOf = core.of;
@@ -109,6 +110,17 @@ describe('throttle', function() {
 			var s2 = limit.throttle(1, limit.throttle(2, te.atTimes([])));
 			expect(s1.source.period).toBe(s2.source.period);
 			expect(s1.source.period).toBe(2);
+		});
+
+		it('should commute map', function() {
+			function id(x) {
+				return x;
+			}
+			var s = limit.throttle(1, map(id, fromArray([1, 2, 3, 4])));
+
+			expect(s.source instanceof Map).toBe(true);
+			expect(s.source.f).toBe(id);
+			expect(s.source.source.period).toBe(1);
 		});
 	});
 

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -8,6 +8,7 @@ var delay = require('../lib/combinator/delay').delay;
 var join = require('../lib/combinator/flatMap').join;
 var zip = require('../lib/combinator/zip').zip;
 var transform = require('../lib/combinator/transform');
+var iterate = require('../lib/source/iterate').iterate;
 var merge = require('../lib/combinator/merge').merge;
 var take = require('../lib/combinator/slice').take;
 var observe = require('../lib/combinator/observe').observe;
@@ -103,23 +104,21 @@ describe('debounce', function() {
 
 describe('throttle', function() {
 	it('should exclude items that are too frequent', function() {
-
-		var n = 10;
-		var i = 0;
-		var s = take(n, map(function() {
-			return i++;
-		}, periodic(1)));
-
+		var s = te.atTimes([
+			{ time: 0, value: 0 },
+			{ time: 1, value: 1 },
+			{ time: 2, value: 2 },
+			{ time: 3, value: 3 },
+			{ time: 4, value: 4 }
+		]);
 		var throttled = limit.throttle(2, s);
 
-		return te.collectEvents(throttled, te.ticks(n))
+		return te.collectEvents(throttled, te.ticks(5))
 			.then(function(events) {
 				expect(events).toEqual([
 					{ time: 0, value: 0 },
 					{ time: 2, value: 2 },
-					{ time: 4, value: 4 },
-					{ time: 6, value: 6 },
-					{ time: 8, value: 8 }
+					{ time: 4, value: 4 }
 				]);
 			});
 	});


### PR DESCRIPTION
Based on similar principles as slice fusion and map-slice commutation from #242:

1. `throttle(n).throttle(m)` can be fused to `.throttle(max(n, m))`, and
2. `.map(f).throttle(n)` can be commuted to `.throttle(n).map(f)`, since map cannot change the time or proportion of events.

Also, updated throttle test to use the `atTimes` helper, for a more reliable test.  All existing tests pass.

### Todo

- [x] Add test to verify that fusion happens
- [x] Add test to verify that commutation happens