### PR TITLE
Make scan observe stream immediately

### DIFF
--- a/lib/combinator/accumulate.js
+++ b/lib/combinator/accumulate.js
@@ -5,7 +5,8 @@
 var Stream = require('../Stream');
 var Pipe = require('../sink/Pipe');
 var runSource = require('../runSource');
-var cons = require('./build').cons;
+var dispose = require('../disposable/dispose');
+var PropagateTask = require('../scheduler/PropagateTask');
 
 exports.scan = scan;
 exports.reduce = reduce;
@@ -19,8 +20,20 @@ exports.reduce = reduce;
  * @returns {Stream} new stream containing successive reduce results
  */
 function scan(f, initial, stream) {
-	return cons(initial, new Stream(new Accumulate(ScanSink, f, initial, stream.source)));
+	return new Stream(new Scan(f, initial, stream.source));
 }
+
+function Scan(f, z, source) {
+	this.source = source;
+	this.f = f;
+	this.value = z;
+}
+
+Scan.prototype.run = function(sink, scheduler) {
+	var d1 = scheduler.asap(PropagateTask.event(this.value, sink));
+	var d2 = this.source.run(new ScanSink(this.f, this.value, sink), scheduler);
+	return dispose.all([d1, d2]);
+};
 
 function ScanSink(f, z, sink) {
 	this.f = f;
@@ -47,35 +60,34 @@ ScanSink.prototype.end = Pipe.prototype.end;
  * @returns {Promise} promise for the file result of the reduce
  */
 function reduce(f, initial, stream) {
-	return runSource.withDefaultScheduler(noop, new Accumulate(AccumulateSink, f, initial, stream.source));
+	return runSource.withDefaultScheduler(noop, new Reduce(f, initial, stream.source));
 }
 
-function Accumulate(SinkType, f, z, source) {
-	this.SinkType = SinkType;
+function Reduce(f, z, source) {
+	this.source = source;
 	this.f = f;
 	this.value = z;
-	this.source = source;
 }
 
-Accumulate.prototype.run = function(sink, scheduler) {
-	return this.source.run(new this.SinkType(this.f, this.value, sink), scheduler);
+Reduce.prototype.run = function(sink, scheduler) {
+	return this.source.run(new ReduceSink(this.f, this.value, sink), scheduler);
 };
 
-function AccumulateSink(f, z, sink) {
+function ReduceSink(f, z, sink) {
 	this.f = f;
 	this.value = z;
 	this.sink = sink;
 }
 
-AccumulateSink.prototype.event = function(t, x) {
+ReduceSink.prototype.event = function(t, x) {
 	var f = this.f;
 	this.value = f(this.value, x);
 	this.sink.event(t, this.value);
 };
 
-AccumulateSink.prototype.error = Pipe.prototype.error;
+ReduceSink.prototype.error = Pipe.prototype.error;
 
-AccumulateSink.prototype.end = function(t) {
+ReduceSink.prototype.end = function(t) {
 	this.sink.end(t, this.value);
 };
 

--- a/lib/scheduler/Scheduler.js
+++ b/lib/scheduler/Scheduler.js
@@ -27,6 +27,8 @@ ScheduledTask.prototype.cancel = function() {
 	return this.task.dispose();
 };
 
+ScheduledTask.prototype.dispose = ScheduledTask.prototype.cancel;
+
 function runTask(task) {
 	try {
 		return task.run();


### PR DESCRIPTION
As discovered in #208, the underlying use of `continueWith` (via `concat` via `startWith`) in scan was delaying observation of the input stream.  This caused a race condition with later combinators that may choose not to emit an event until all their input streams have emitted at least one event, such as `combine` and `sample`.

This changes makes scan *simultaneously* arrange to emit the initial value, and observe the input stream.  Since streams *must* use the scheduler to begin emitting events, this is safe (or, to put it another way, any stream that emits an event synchronously--and thus would win the race with the initial value--is broken and should be fixed).

Fix #208