### PR TITLE
Add thru(), functional-fluent adapter method

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -17,7 +17,8 @@ function noop () {};
 module.exports = {
   require: {
     most: most,
-   'transducers-js': require('transducers-js')
+		'@most/hold': require('@most/hold'),
+		'transducers-js': require('transducers-js')
   },
 
   globals: {

--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -17,8 +17,8 @@ function noop () {};
 module.exports = {
   require: {
     most: most,
-		'@most/hold': require('@most/hold'),
-		'transducers-js': require('transducers-js')
+    '@most/hold': require('@most/hold'),
+    'transducers-js': require('transducers-js')
   },
 
   globals: {

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,8 @@ most.js API
 	* [during](#during)
 1. Looping
 	* [loop](#loop)
+1. Adapting fluent APIs
+	* [thru](#thru)
 1. Consuming streams
 	* [reduce](#reduce)
 	* [observe](#observe), alias [forEach](#observe)
@@ -325,8 +327,6 @@ Create a stream containing events from the provided [EventTarget](https://develo
 When passing an EventTarget, you can provide `useCapture` as the 3rd parameter, and it will be passed through to `addEventListener` and `removeEventListener`.  When not provided, `useCapture` defaults to `false`.
 
 When the stream ends (for example, by using [take](#take), [takeUntil](#until), etc.), it will automatically be disconnected from the event source.  For example, in the case of DOM events, the underlying DOM event listener will be removed automatically.
-
-
 
 **Notes on EventEmitter**
 
@@ -1064,6 +1064,43 @@ stream.loop(function(values, x) {
 	return { seed: values, value: avg };
 }, [])
 	.observe(console.log.bind(console));
+```
+
+## Adapting fluent APIs
+
+### thru
+
+####`stream.thru(transform) -> Stream`
+
+`transform(stream: Stream) -> Stream`
+
+Use a functional API in fluent style.
+
+Functional APIs allow for the highest degree of modularity via external packages, such as [`@most/hold`](https://github.com/mostjs/hold), *without the risks of modifying prototypes*.
+
+If you prefer using fluent APIs, `thru` allows using those functional APIs in a fluent style.  For example:
+
+```js
+import hold from `@most/hold`
+import { click } from `@most/dom-event`
+
+click(someElement)
+  .tap(ev => ev.preventDefault)
+  .map(ev => ev.target.value)
+  .thru(hold)
+  .observer(x => console.log(x))
+```
+
+rather than mixing functional and fluent:
+
+```js
+import hold from `@most/hold`
+import { click } from `@most/dom-event`
+
+hold(click(someElement)
+  .tap(ev => ev.preventDefault)
+  .map(ev => ev.target.value))
+  .observer(x => console.log(x))
 ```
 
 ## Consuming streams

--- a/docs/api.md
+++ b/docs/api.md
@@ -1085,7 +1085,7 @@ import hold from `@most/hold`
 import { click } from `@most/dom-event`
 
 click(someElement)
-  .tap(ev => ev.preventDefault)
+  .tap(ev => ev.preventDefault())
   .map(ev => ev.target.value)
   .thru(hold)
   .observer(x => console.log(x))
@@ -1098,7 +1098,7 @@ import hold from `@most/hold`
 import { click } from `@most/dom-event`
 
 hold(click(someElement)
-  .tap(ev => ev.preventDefault)
+  .tap(ev => ev.preventDefault())
   .map(ev => ev.target.value))
   .observer(x => console.log(x))
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -1081,26 +1081,26 @@ Functional APIs allow for the highest degree of modularity via external packages
 If you prefer using fluent APIs, `thru` allows using those functional APIs in a fluent style.  For example:
 
 ```js
-import hold from `@most/hold`
-import { click } from `@most/dom-event`
+import hold from '@most/hold'
+import { periodic } from 'most'
 
-click(someElement)
-  .tap(ev => ev.preventDefault())
-  .map(ev => ev.target.value)
+periodic(10, 1)
+	.take(5)
+	.scan((total, increment) => total + increment, 0)
   .thru(hold)
-  .observer(x => console.log(x))
+  .observe(x => console.log(x))
 ```
 
 rather than mixing functional and fluent:
 
 ```js
-import hold from `@most/hold`
-import { click } from `@most/dom-event`
+import hold from '@most/hold'
+import { periodic } from 'most'
 
-hold(click(someElement)
-  .tap(ev => ev.preventDefault())
-  .map(ev => ev.target.value))
-  .observer(x => console.log(x))
+hold(periodic(10, 1)
+	.take(5)
+	.scan((total, increment) => total + increment, 0))
+  .observe(x => console.log(x))
 ```
 
 ## Consuming streams

--- a/docs/api.md
+++ b/docs/api.md
@@ -1087,8 +1087,8 @@ import { periodic } from 'most'
 periodic(10, 1)
 	.take(5)
 	.scan((total, increment) => total + increment, 0)
-  .thru(hold)
-  .observe(x => console.log(x))
+	.thru(hold)
+	.observe(x => console.log(x))
 ```
 
 rather than mixing functional and fluent:
@@ -1100,7 +1100,7 @@ import { periodic } from 'most'
 hold(periodic(10, 1)
 	.take(5)
 	.scan((total, increment) => total + increment, 0))
-  .observe(x => console.log(x))
+	.observe(x => console.log(x))
 ```
 
 ## Consuming streams

--- a/lib/combinator/thru.js
+++ b/lib/combinator/thru.js
@@ -1,0 +1,7 @@
+/** @license MIT License (c) copyright 2010-2016 original author or authors */
+/** @author Brian Cavalier */
+/** @author John Hann */
+
+exports.thru = function thru(f, stream) {
+	return f(stream);
+}

--- a/most.js
+++ b/most.js
@@ -27,8 +27,6 @@ exports.periodic = periodic;
 
 var thru = require('./lib/combinator/thru').thru;
 
-exports.thru = thru;
-
 /**
  * Adapt a functional stream transform to fluent style.
  * It applies f to the this stream object

--- a/most.js
+++ b/most.js
@@ -23,6 +23,24 @@ exports.from     = from;
 exports.periodic = periodic;
 
 //-----------------------------------------------------------------------
+// Fluent adapter
+
+var thru = require('./lib/combinator/thru');
+
+exports.thru = thru;
+
+/**
+ * Adapt a functional stream transform to fluent style.
+ * It applies f to the this stream object
+ * @param  {function(s: Stream): Stream} f function that
+ * receives the stream itself and must return a new stream
+ * @return {Stream}
+ */
+Stream.prototype.thru = function(f) {
+	return thru(f, this);
+}
+
+//-----------------------------------------------------------------------
 // Creating
 
 var create = require('./lib/source/create');

--- a/most.js
+++ b/most.js
@@ -25,7 +25,7 @@ exports.periodic = periodic;
 //-----------------------------------------------------------------------
 // Fluent adapter
 
-var thru = require('./lib/combinator/thru');
+var thru = require('./lib/combinator/thru').thru;
 
 exports.thru = thru;
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
-    "@most/hold": "^1.1.1",
+    "@most/hold": "^1.2.0",
     "buster": "~0.7",
     "eslint": "^1.10.3",
     "markdown-doctest": "^0.3.4",
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "@most/multicast": "^1.1.1",
-    "@most/prelude": "^1.1.0"
+    "@most/prelude": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "author": "brian@hovercraftstudios.com",
   "license": "MIT",
   "devDependencies": {
+    "@most/hold": "^1.1.1",
     "buster": "~0.7",
     "eslint": "^1.10.3",
     "markdown-doctest": "^0.3.4",

--- a/test/combinator/thru-test.js
+++ b/test/combinator/thru-test.js
@@ -1,0 +1,29 @@
+require('buster').spec.expose();
+var expect = require('buster').expect;
+
+var thru = require('../../lib/combinator/thru').thru;
+
+describe('thru', function() {
+	it('should apply f to stream', function() {
+		var stream = {}
+		var expected = {}
+		function f(s) {
+			return expected;
+		}
+
+		expect(f(stream)).toBe(expected)
+	});
+
+	it('should throw synchronously if f throws synchronously', function() {
+		var error = new Error();
+		function f() {
+			throw error;
+		}
+
+		try {
+			f({});
+		} catch(e) {
+			expect(e).toBe(error);
+		}
+	});
+});


### PR DESCRIPTION
Most's current direction is to provide non-core functional APIs via separate packages, which gets us true modularity without the problems of modifying prototypes.  This PR adds `stream.thru(f)` to allow functional APIs to be used in a fluent way.  For folks who prefer fluent APIs, this allows using those functional APIs with of mixing the two styles.

For example, fluent users have the option of using `thru`:

```js
import hold from `@most/hold`
import { click } from `@most/dom-event`

click(someElement)
  .tap(ev => ev.preventDefault)
  .map(ev => ev.target.value)
  .thru(hold)
  .observer(x => console.log(x))
```

rather than mixing functional and fluent:

```js
import hold from `@most/hold`
import { click } from `@most/dom-event`

hold(click(someElement)
  .tap(ev => ev.preventDefault)
  .map(ev => ev.target.value))
  .observer(x => console.log(x))
```

### Todo

- [x] Docs & examples