### PR TITLE
Use observation time for just and fromArray

### DIFF
--- a/lib/combinator/limit.js
+++ b/lib/combinator/limit.js
@@ -119,7 +119,7 @@ DebounceSink.prototype._clearTimer = function() {
 	if(this.timer === null) {
 		return false;
 	}
-	this.timer.cancel();
+	this.timer.dispose();
 	this.timer = null;
 	return true;
 };

--- a/lib/scheduler/Scheduler.js
+++ b/lib/scheduler/Scheduler.js
@@ -22,12 +22,10 @@ ScheduledTask.prototype.error = function(e) {
 	return this.task.error(this.time, e);
 };
 
-ScheduledTask.prototype.cancel = function() {
+ScheduledTask.prototype.dispose = function() {
 	this.scheduler.cancel(this);
 	return this.task.dispose();
 };
-
-ScheduledTask.prototype.dispose = ScheduledTask.prototype.cancel;
 
 function runTask(task) {
 	try {

--- a/lib/source/ValueSource.js
+++ b/lib/source/ValueSource.js
@@ -12,13 +12,5 @@ function ValueSource(emit, x) {
 }
 
 ValueSource.prototype.run = function(sink, scheduler) {
-	return new ValueProducer(this.emit, this.value, sink, scheduler);
-};
-
-function ValueProducer(emit, x, sink, scheduler) {
-	this.task = scheduler.asap(new PropagateTask(emit, x, sink));
-}
-
-ValueProducer.prototype.dispose = function() {
-	return this.task.cancel();
+	return scheduler.asap(new PropagateTask(this.emit, this.value, sink));
 };

--- a/lib/source/core.js
+++ b/lib/source/core.js
@@ -21,8 +21,8 @@ function streamOf(x) {
 }
 
 function emit(t, x, sink) {
-	sink.event(0, x);
-	sink.end(0, void 0);
+	sink.event(t, x);
+	sink.end(t, void 0);
 }
 
 /**

--- a/lib/source/fromArray.js
+++ b/lib/source/fromArray.js
@@ -16,31 +16,19 @@ function ArraySource(a) {
 }
 
 ArraySource.prototype.run = function(sink, scheduler) {
-	return new ArrayProducer(this.array, sink, scheduler);
-};
-
-function ArrayProducer(array, sink, scheduler) {
-	this.scheduler = scheduler;
-	this.task = new PropagateTask(runProducer, array, sink);
-	scheduler.asap(this.task);
-}
-
-ArrayProducer.prototype.dispose = function() {
-	return this.task.dispose();
+	var task = new PropagateTask(runProducer, this.array, sink);
+	scheduler.asap(task);
+	return task;
 };
 
 function runProducer(t, array, sink) {
-	produce(this, array, sink);
-}
-
-function produce(task, array, sink) {
-	for(var i=0, l=array.length; i<l && task.active; ++i) {
-		sink.event(0, array[i]);
+	for(var i=0, l=array.length; i<l && this.active; ++i) {
+		sink.event(t, array[i]);
 	}
 
-	task.active && end();
+	this.active && end(t);
 
-	function end() {
-		sink.end(0);
+	function end(t) {
+		sink.end(t);
 	}
 }

--- a/lib/source/fromArray.js
+++ b/lib/source/fromArray.js
@@ -16,9 +16,7 @@ function ArraySource(a) {
 }
 
 ArraySource.prototype.run = function(sink, scheduler) {
-	var task = new PropagateTask(runProducer, this.array, sink);
-	scheduler.asap(task);
-	return task;
+	return scheduler.asap(new PropagateTask(runProducer, this.array, sink));
 };
 
 function runProducer(t, array, sink) {

--- a/lib/source/periodic.js
+++ b/lib/source/periodic.js
@@ -25,13 +25,8 @@ function Periodic(period, value) {
 }
 
 Periodic.prototype.run = function(sink, scheduler) {
-	var task = scheduler.periodic(this.period, new PropagateTask(emit, this.value, sink));
-	return dispose.create(cancelTask, task);
+	return scheduler.periodic(this.period, new PropagateTask(emit, this.value, sink));
 };
-
-function cancelTask(task) {
-	task.cancel();
-}
 
 function emit(t, x, sink) {
 	sink.event(t, x);

--- a/test/helper/testEnv.js
+++ b/test/helper/testEnv.js
@@ -95,5 +95,5 @@ function cancelAll(tasks) {
 }
 
 function cancelOne(task) {
-	return task.cancel();
+	return task.dispose();
 }


### PR DESCRIPTION
Previously, these were just using `0` as their `t` value.  It seems tough to me to rigorously (mathematically) justify any value of `t` for something like `just(1)`.  When does 1 "occur"?

**tl;dr;** See lib/source/core.js and lib/source/fromArray.js for the important changes.

So, after some discussion on gitter, it seemed like the right thing to do is to make a *practical* choice about `t`.  We bounced around several ideas:

1. Use observation time, i.e. `scheduler.now()` at the time the Stream provides the value to an observer.
  - There was discussion about what the time origin of `scheduler.now()` should be.  For example, currently it is the same origin as JavaScript `Date`, the unix epoch.  Another option is *program start*: the scheduler would use `Date.now()` at VM startup time as the time origin, and `t` values would start at zero at program start and increase from there. That led to the discussion of *stream-local* time origin ...
2. Use `t=0`, and switch to using stream-local times and use `t=0`--that is, *every* stream (not only `just` and `from`) gets it's own origin at `t=0`.  This is actually similar to 1, but with a per-stream time origin rather than a global time origin.
3. Use construction time, i.e. `scheduler.now()` at the time `just(1)` is called.  One technical hurdle with this is that, at construction time, streams do not know what scheduler they will be asked to use.  They cannot call `scheduler.now()` until they are first observed.

The change to do 1 was trivial, so I figured I'd put it up for discussion.  The change to use program start time would be relatively simple, but I decided not to do it until there's evidence that it's "better" in some way.  The change to do 2 is more involved, but certainly possible.  The change to do 3 would be much more work.

Along the way, I simplified a bunch of code by relying on the fact that ScheduledTask implements Disposable.  We'll probably want to keep those changes even if we don't switch to observation time for `just` and `from`.