### PR TITLE
Deprecate create, prepare to move to separate package

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -372,6 +372,8 @@ most.fromEvent('click', container)
 <a name="mostcreate"/>
 ### most.create
 
+**Deprecated**: `most.create` will be moved to a separate package.  Once that package is available, `most.create` will be removed.
+
 ####`most.create(publisher) -> Stream`
 
 Create a push-stream for imperatively pushing events, primarily for situations where existing, declarative sources, like [`fromEvent`](#mostfromevent), [`unfold`](#mostunfold), [`iterate`](#mostiterate), etc. can't be used.

--- a/lib/source/create.js
+++ b/lib/source/create.js
@@ -9,6 +9,9 @@ var tryEvent = require('./tryEvent');
 
 exports.create = create;
 
+/**
+ * @deprecated
+ */
 function create(run) {
 	return new Stream(new MulticastSource(new SubscriberSource(run)));
 }

--- a/most.js
+++ b/most.js
@@ -44,6 +44,7 @@ Stream.prototype.thru = function(f) {
 var create = require('./lib/source/create');
 
 /**
+ * @deprecated
  * Create a stream by imperatively pushing events.
  * @param {function(add:function(x), end:function(e)):function} run function
  *  that will receive 2 functions as arguments, the first to add new values to the


### PR DESCRIPTION
The plan is to move `most.create` to a `@most/<package>`.

It has always been a last resort for situations that force using an imperative push approach, and so is outside most.js's core mission, which focuses on providing a declarative API.  Moving it to a separate package means it will still be available for those situations, but will also help to make clear the imperative/declarative distinction.
