### PR TITLE
chore(TS): update typescript definitons

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -23,7 +23,7 @@ declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A
 
 export interface Sink<A> {
   event(time: number, value: A): void;
-  end(time: number, value: A): void;
+  end(time: number, value?: A): void;
   error(time: number, err: Error): void;
 }
 
@@ -47,7 +47,7 @@ export interface Scheduler {
   periodic(task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;
-  cancelAll(predicate: (val: any) => boolean): void;
+  cancelAll(predicate: (task: Task) => boolean): void;
 }
 
 export interface Disposable<A> {
@@ -61,7 +61,7 @@ export interface Source<A> {
 export interface Subscriber<A> {
   next(value: A): void;
   error(err: Error): void;
-  complete(value: A): void;
+  complete(value?: A): void;
 }
 
 export interface Subscription<A> {

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -47,7 +47,7 @@ declare interface Scheduler {
   periodic(task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;
-  cancelAll(predicate: (any) => boolean): void;
+  cancelAll(predicate: (val: any) => boolean): void;
 }
 
 declare interface Disposable<A> {

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -69,8 +69,6 @@ declare interface Subscription<A> {
 }
 
 export interface Stream<A> {
-  source: Source<A>;
-
   reduce<B>(f: (b: B, a: A) => B, b: B): Promise<B>;
   observe(f: (a: A) => any): Promise<any>;
   forEach(f: (a: A) => any): Promise<any>;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -225,6 +225,10 @@ declare interface DisposeFn {
   (): void|Promise<any>;
 }
 
+export class Stream<A> implements Stream<A>{
+  constructor(source: Source<A>);
+}
+
 export function create<A>(f: (add: (a: A) => any, end: (x: any) => any, error: (e: Error) => any) => void|DisposeFn): Stream<A>;
 export function just<A>(a: A): Stream<A>;
 export function of<A>(a: A): Stream<A>;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -21,26 +21,26 @@ declare interface Iterable<A> {}
 
 declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A>, any, any>;
 
-declare interface Sink<A> {
+export interface Sink<A> {
   event(time: number, value: A): void;
   end(time: number, value: A): void;
   error(time: number, err: Error): void;
 }
 
-declare interface Task {
+export interface Task {
   run(time: number): void;
   error(time: number, e: Error): void;
   dispose(): void;
 }
 
-declare interface ScheduledTask {
+export interface ScheduledTask {
   task: Task;
   run(): void;
   error(err: Error): void;
   dispose(): void;
 }
 
-declare interface Scheduler {
+export interface Scheduler {
   now(): number;
   asap(task: Task): ScheduledTask;
   delay(task: Task): ScheduledTask;
@@ -50,21 +50,21 @@ declare interface Scheduler {
   cancelAll(predicate: (val: any) => boolean): void;
 }
 
-declare interface Disposable<A> {
+export interface Disposable<A> {
   dispose(): void | Promise<A>;
 }
 
-declare interface Source<A> {
+export interface Source<A> {
   run (sink: Sink<A>, scheduler: Scheduler): Disposable<A>;
 }
 
-declare interface Subscriber<A> {
+export interface Subscriber<A> {
   next(value: A): void;
   error(err: Error): void;
   complete(value: A): void;
 }
 
-declare interface Subscription<A> {
+export interface Subscription<A> {
   unsubscribe(): void;
 }
 
@@ -74,8 +74,6 @@ export interface Stream<A> {
   forEach(f: (a: A) => any): Promise<any>;
   drain(): Promise<any>;
   subscribe(subscriber: Subscriber<A>): Subscription<A>;
-  
-  thru<B>(f: (s: Stream<A>) => Stream<B>): Stream<B>;
 
   constant<B>(b: B): Stream<B>;
   map<B>(f: (a: A) => B): Stream<B>;
@@ -223,7 +221,8 @@ declare interface DisposeFn {
   (): void|Promise<any>;
 }
 
-export class Stream<A> implements Stream<A>{
+export class Stream<A> {
+  source: Source<A>;
   constructor(source: Source<A>);
 }
 


### PR DESCRIPTION
Add subscribe()
export Stream class needed to write 3rd party libraries in TypeScript
Add Source interface
Add Sink and Scheduler, and Disposable interfaces to complete Source interface
Add Task, ScheduledTask to complete Scheduler interface
Add Subscriber and Subscrition interfaces as needed by `subscribe()`