### PR TITLE
Add links to mostjs/create, port fixes

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -447,7 +447,7 @@ most.fromEvent('click', container)
 <a name="mostcreate"/>
 ### most.create
 
-**Deprecated**: `most.create` will be moved to a separate package.  Once that package is available, `most.create` will be removed.
+**Deprecated**: [Use `@most/create` instead](https://github.com/mostjs/create)
 
 ####`most.create(publisher) -> Stream`
 

--- a/lib/sink/DeferredSink.js
+++ b/lib/sink/DeferredSink.js
@@ -18,29 +18,33 @@ DeferredSink.prototype.event = function(t, x) {
 	}
 
 	if(this.events.length === 0) {
-		defer(new PropagateAllTask(this.sink, this.events));
+		defer(new PropagateAllTask(this.sink, t, this.events));
 	}
 
 	this.events.push({ time: t, value: x });
+};
+
+DeferredSink.prototype.end = function(t, x) {
+	if(!this.active) {
+		return;
+	}
+
+	this._end(new EndTask(t, x, this.sink));
 };
 
 DeferredSink.prototype.error = function(t, e) {
 	this._end(new ErrorTask(t, e, this.sink));
 };
 
-DeferredSink.prototype.end = function(t, x) {
-	this._end(new EndTask(t, x, this.sink));
-};
-
 DeferredSink.prototype._end = function(task) {
 	this.active = false;
-	this.events = void 0;
 	defer(task);
 }
 
-function PropagateAllTask(sink, events) {
+function PropagateAllTask(sink, time, events) {
 	this.sink = sink;
 	this.events = events;
+	this.time = time;
 }
 
 PropagateAllTask.prototype.run = function() {
@@ -50,6 +54,7 @@ PropagateAllTask.prototype.run = function() {
 
 	for(var i = 0, l = events.length; i<l; ++i) {
 		event = events[i];
+		this.time = event.time;
 		sink.event(event.time, event.value);
 	}
 
@@ -57,7 +62,7 @@ PropagateAllTask.prototype.run = function() {
 };
 
 PropagateAllTask.prototype.error = function(e) {
-	this.sink.error(0, e);
+	this.sink.error(this.time, e);
 };
 
 function EndTask(t, x, sink) {

--- a/lib/source/create.js
+++ b/lib/source/create.js
@@ -5,12 +5,11 @@
 var Stream = require('../Stream');
 var MulticastSource = require('@most/multicast').MulticastSource;
 var DeferredSink = require('../sink/DeferredSink');
-var tryEvent = require('./tryEvent');
 
 exports.create = create;
 
 /**
- * @deprecated
+ * @deprecated Use `@most/create` instead: https://github.com/mostjs/create
  */
 function create(run) {
 	return new Stream(new MulticastSource(new SubscriberSource(run)));
@@ -27,7 +26,6 @@ SubscriberSource.prototype.run = function(sink, scheduler) {
 function Subscription(sink, scheduler, subscribe) {
 	this.sink = sink;
 	this.scheduler = scheduler;
-	this.active = true;
 	this._unsubscribe = this._init(subscribe);
 }
 
@@ -41,34 +39,14 @@ Subscription.prototype._init = function(subscribe) {
 	}
 
 	function add(x) {
-		s._add(x);
+		s.sink.event(s.scheduler.now(), x);
 	}
 	function end(x) {
-		s._end(x);
+		s.sink.end(s.scheduler.now(), x);
 	}
 	function error(e) {
-		s._error(e);
+		s.sink.error(s.scheduler.now(), e);
 	}
-};
-
-Subscription.prototype._add = function(x) {
-	if(!this.active) {
-		return;
-	}
-	tryEvent.tryEvent(this.scheduler.now(), x, this.sink);
-};
-
-Subscription.prototype._end = function(x) {
-	if(!this.active) {
-		return;
-	}
-	this.active = false;
-	tryEvent.tryEnd(this.scheduler.now(), x, this.sink);
-};
-
-Subscription.prototype._error = function(x) {
-	this.active = false;
-	this.sink.error(this.scheduler.now(), x);
 };
 
 Subscription.prototype.dispose = function() {


### PR DESCRIPTION
This adds links to [`@most/create`](https://github.com/mostjs/create), and applies recent fixes from from https://github.com/mostjs/create/pull/2, as well as other simplifications from that repo.