### PR TITLE
Remove Promise from typescript definition

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -1,21 +1,6 @@
 declare type SeedValue<S, V> = { seed: S, value: V };
 declare type TimeValue<V>    = { time: number, value: V };
 
-declare interface Thenable<A> {
-    then<U>(onFulfilled?: (value: A) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-    then<U>(onFulfilled?: (value: A) => U | Thenable<U>, onRejected?: (error: any) => void): Thenable<U>;
-    catch<U>(onRejected?: (error: any) => U | Thenable<U>): Thenable<U>;
-}
-
-declare interface Promise<A> {
-  constructor(callback: (resolve: (value?: A | Thenable<A>) => void, reject: (error?: any) => void) => void): Promise<A>;
-
-  then<U>(onFulfilled?: (value: A) => U | Thenable<U>, onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
-  then<U>(onFulfilled?: (value: A) => U | Thenable<U>, onRejected?: (error: any) => void): Promise<U>;
-
-  catch<U>(onRejected?: (error: any) => U | Thenable<U>): Promise<U>;
-}
-
 declare interface Generator<A, B, C> {}
 declare interface Iterable<A> {}
 


### PR DESCRIPTION
Hello!

The small local Promise definition embedded in `most.d.ts` seems both unneeded and conflicting with two of the most widely used typescript setups:

- Compiling with ES6 as a target, in which case the typescript compiler automatically add `lib.es6.d.ts` which come with a complete Promise definition.

- Compiling with ES5 as a target and including `es6shim.d.ts` which also come with a comprehensive Promise definition. For instance, Angular 2 do it (can't believe I took them as an example! :D) and it seems to be widely advised on various stackoverflow posts by even typescript compiler contributors.
This is the setup I'm using and removing the definition fixed all errors.

The local Promise definition also has an incompatible interface. So if I use `fetch` that return a `Promise` defined in one of the 2 above files, then `most.fromPromise` won't accept it.

Cheers

@briancavalier   @TylorS 