### PR TITLE
Allow anything that implements Observable to be returned from getObservable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -235,7 +235,7 @@ most.from([1,2,3,4]): 1234|
 
 Create a stream containing all items from an Iterable or Observable.
 
-The observable must provide minimal draft ES observable compliance as per the [es-observable draft](https://github.com/zenparsing/es-observable): it must have a `[Symbol.observable]()` method that return an object with a well-behaved `.subscribe()` method.
+The observable must provide minimal draft ES observable compliance as per the [es-observable draft](https://github.com/zenparsing/es-observable): it must have a `[Symbol.observable]()` method that returns an object with a well-behaved `.subscribe()` method.
 
 The iterable can be an Array, Array-like, or anything that supports the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/iterable) or [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol), such as a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*). Providing a finite iterable, such as an Array, creates a finite stream. Providing an infinite iterable, such as an infinite generator, creates an infinite stream.
 

--- a/lib/observable/getObservable.js
+++ b/lib/observable/getObservable.js
@@ -8,10 +8,14 @@ module.exports = getObservable;
 
 function getObservable(o) {
 	var obs = null;
-	if(o && typeof o[symbolObservable] === 'function') {
-		obs = o[symbolObservable]();
-		if(!(obs && typeof obs.subscribe === 'function')) {
-			throw new TypeError('invalid observable ' + obs);
+	if(o) {
+		// Access foreign method only once
+		var method = o[symbolObservable];
+		if(typeof method === 'function') {
+			obs = method.call(o);
+			if(!(obs && typeof obs.subscribe === 'function')) {
+				throw new TypeError('invalid observable ' + obs);
+			}
 		}
 	}
 

--- a/lib/observable/getObservable.js
+++ b/lib/observable/getObservable.js
@@ -8,13 +8,10 @@ module.exports = getObservable;
 
 function getObservable(o) {
 	var obs = null;
-	if(o != null && typeof o === 'object') {
-		var method = o[symbolObservable];
-		if(typeof method === 'function') {
-			obs = method.call(o);
-			if(obs == null || typeof obs !== 'object') {
-				throw new TypeError('invalid observable ' + obs);
-			}
+	if(o && typeof o[symbolObservable] === 'function') {
+		obs = o[symbolObservable]();
+		if(!(obs && typeof obs.subscribe === 'function')) {
+			throw new TypeError('invalid observable ' + obs);
 		}
 	}
 

--- a/test/observable/getObservable-test.js
+++ b/test/observable/getObservable-test.js
@@ -9,7 +9,6 @@ describe('getObservable', function() {
 		assert.same(null, getObservable(0));
 		assert.same(null, getObservable(1));
 		assert.same(null, getObservable(undefined));
-		assert.same(null, getObservable(null));
 		assert.same(null, getObservable(''));
 		assert.same(null, getObservable('string'));
 		assert.same(null, getObservable(true));
@@ -20,6 +19,7 @@ describe('getObservable', function() {
 		assert.same(null, getObservable({}));
 		assert.same(null, getObservable(null));
 		assert.same(null, getObservable(function() {}));
+		assert.same(null, getObservable([]));
 	});
 
 	it('should throw TypeError for invalid observable', function() {

--- a/test/observable/getObservable-test.js
+++ b/test/observable/getObservable-test.js
@@ -6,17 +6,20 @@ var getObservable = require('../../lib/observable/getObservable');
 
 describe('getObservable', function() {
 	it('should return null for non-object', function() {
+		assert.same(null, getObservable(0));
 		assert.same(null, getObservable(1));
 		assert.same(null, getObservable(undefined));
 		assert.same(null, getObservable(null));
+		assert.same(null, getObservable(''));
 		assert.same(null, getObservable('string'));
 		assert.same(null, getObservable(true));
+		assert.same(null, getObservable(false));
 	});
 
 	it('should return null for non-observable object', function() {
 		assert.same(null, getObservable({}));
 		assert.same(null, getObservable(null));
-		assert.same(null, getObservable(() => {}));
+		assert.same(null, getObservable(function() {}));
 	});
 
 	it('should throw TypeError for invalid observable', function() {
@@ -44,7 +47,7 @@ describe('getObservable', function() {
 
 	it('should return observable if valid', function() {
 		var outer = {};
-		var inner = { subscribe: () => {} };
+		var inner = { subscribe: function() {} };
 		outer[symbolObservable] = function() {
 			return inner
 		}

--- a/test/observable/getObservable-test.js
+++ b/test/observable/getObservable-test.js
@@ -8,13 +8,15 @@ describe('getObservable', function() {
 	it('should return null for non-object', function() {
 		assert.same(null, getObservable(1));
 		assert.same(null, getObservable(undefined));
-		assert.same(null, getObservable(''));
+		assert.same(null, getObservable(null));
+		assert.same(null, getObservable('string'));
 		assert.same(null, getObservable(true));
 	});
 
 	it('should return null for non-observable object', function() {
 		assert.same(null, getObservable({}));
 		assert.same(null, getObservable(null));
+		assert.same(null, getObservable(() => {}));
 	});
 
 	it('should throw TypeError for invalid observable', function() {
@@ -42,7 +44,7 @@ describe('getObservable', function() {
 
 	it('should return observable if valid', function() {
 		var outer = {};
-		var inner = {};
+		var inner = { subscribe: () => {} };
 		outer[symbolObservable] = function() {
 			return inner
 		}


### PR DESCRIPTION
## Open the flood gates!
![](http://kyletolle.github.io/dsw_webhooks_talk/stampede.gif)

In response to [issue#283](https://github.com/cujojs/most/issues/283), this PR proposes letting any *thing* that implements the Observable interface through the `getObservable` function. Right now it appears this function is only used in the `most.from` method.

The criteria has been changed to reflect the wording in the API docs for `most.from` [here](https://github.com/cujojs/most/blob/master/docs/api.md#mostfrom):

> ... it must have a [Symbol.observable]() method that return an object with a well-behaved .subscribe() method.

*(maybe I should add a spelling correction for return?)*

The following was changed:
* check if truthy `o` has an observable Symbol function (`oSf`) on it.
* remove the unbinding and rebinding of the `oSf` (Did not see the need to do this, will totes put back if ya want it)
* verify that the *thing* returned from the `oSf` provides a `subscribe` method. Pretty sure it gets checked further down the line, but makes sense to reject in `most.from`. This is also an opinion and will also change this back to just checking for an `object` type, if desired.
* Added some additional assertions to provide, falsey and truthy values for possible types.
* updated the is valid spec to account for the need to have the `subscribe` method.