### PR TITLE
chore(documentation) 

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1332,7 +1332,7 @@ stream2:                   -1---2---3---4->
 stream1.zip(add, stream2): -2---4---6---8->
 ```
 
-Zipping correlates *by index* corresponding events from two or more input streams.  Fast streams must wait for slow streams.  For pull streams, this does not cause any buffering.  However, when zipping push streams, a fast push stream, such as those created by [`most.create`](https://github.com/mostjs/multicast) and [`most.fromEvent`](#mostfromevent) will be forced to buffer events so they can be correlated with corresponding events from the slower stream.
+Zipping correlates *by index* corresponding events from two or more input streams.  Fast streams must wait for slow streams.  For pull streams, this does not cause any buffering.  However, when zipping push streams, a fast push stream, such as those created by [`mostjs/multicast`](https://github.com/mostjs/multicast) and [`most.fromEvent`](#mostfromevent) will be forced to buffer events so they can be correlated with corresponding events from the slower stream.
 
 A zipped stream ends when any one of its input streams ends.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,7 +17,6 @@ most.js API
 	* [most.unfold](#mostunfold)
 	* [most.generate](#mostgenerate)
 	* [most.fromEvent](#mostfromevent)
-	* [most.create](#mostcreate)
 	* [startWith](#startwith)
 	* [concat](#concat)
 1. Handling errors
@@ -1333,7 +1332,7 @@ stream2:                   -1---2---3---4->
 stream1.zip(add, stream2): -2---4---6---8->
 ```
 
-Zipping correlates *by index* corresponding events from two or more input streams.  Fast streams must wait for slow streams.  For pull streams, this does not cause any buffering.  However, when zipping push streams, a fast push stream, such as those created by [`most.create`](#mostcreate) and [`most.fromEvent`](#mostfromevent) will be forced to buffer events so they can be correlated with corresponding events from the slower stream.
+Zipping correlates *by index* corresponding events from two or more input streams.  Fast streams must wait for slow streams.  For pull streams, this does not cause any buffering.  However, when zipping push streams, a fast push stream, such as those created by [`most.create`](https://github.com/mostjs/multicast) and [`most.fromEvent`](#mostfromevent) will be forced to buffer events so they can be correlated with corresponding events from the slower stream.
 
 A zipped stream ends when any one of its input streams ends.
 

--- a/docs/recipes/event-delegation.md
+++ b/docs/recipes/event-delegation.md
@@ -9,7 +9,7 @@ from the element.
 
 The 2nd example is similar, however we use jQuery to handle event delegation.
 
-We use [most.create](../api.md#mostcreate) to produce a push-stream off of those click events.
+We use [mostjs/create](https://github.com/mostjs/multicast) to produce a push-stream off of those click events.
 Essentially each time a user clicks on the `.inner` that event is added to the
 stream which can be observed and processed in a similar manner to the 1st example.
 


### PR DESCRIPTION
remove reference of `create`
reference `create` to https://github.com/mostjs/multicast where needed