### PR TITLE
Handle fromEvent capture arg with default value

### DIFF
--- a/lib/source/fromEvent.js
+++ b/lib/source/fromEvent.js
@@ -12,16 +12,19 @@ exports.fromEvent = fromEvent;
  * Create a stream from an EventTarget, such as a DOM Node, or EventEmitter.
  * @param {String} event event type name, e.g. 'click'
  * @param {EventTarget|EventEmitter} source EventTarget or EventEmitter
- * @param {boolean?} useCapture for DOM events, whether to use
+ * @param {*?} capture for DOM events, whether to use
  *  capturing--passed as 3rd parameter to addEventListener.
  * @returns {Stream} stream containing all events of the specified type
  * from the source.
  */
-function fromEvent(event, source /*, useCapture = false */) {
+function fromEvent(event, source, capture) {
 	var s;
 
 	if(typeof source.addEventListener === 'function' && typeof source.removeEventListener === 'function') {
-		var capture = arguments.length > 2 && !!arguments[2];
+		if(arguments.length < 3) {
+			capture = false
+		}
+
 		s = new EventTargetSource(event, source, capture);
 	} else if(typeof source.addListener === 'function' && typeof source.removeListener === 'function') {
 		s = new EventEmitterSource(event, source);

--- a/test/accumulate-test.js
+++ b/test/accumulate-test.js
@@ -1,6 +1,6 @@
 import { spec, referee } from 'buster';
-const { describe, it } = spec
-const { fail, assert } = referee;
+const { describe, it } = spec;
+const { assert } = referee;
 
 import Stream from '../lib/Stream'
 import { scan, reduce } from '../lib/combinator/accumulate'

--- a/test/source/fromEvent-test.js
+++ b/test/source/fromEvent-test.js
@@ -4,6 +4,7 @@ var expect = require('buster').expect;
 var events = require('../../lib/source/fromEvent');
 var fromEvent = events.fromEvent;
 var reduce = require('../../lib/combinator/accumulate').reduce;
+var drain = require('../../lib/combinator/observe').drain;
 var observe = require('../../lib/combinator/observe').observe;
 var take = require('../../lib/combinator/slice').take;
 var FakeEventTarget = require('../helper/FakeEventTarget');
@@ -39,6 +40,25 @@ describe('fromEvent', function() {
 				expect(tick).toBe(1);
 			}, take(1, s));
 		});
+
+		it('should pass capture argument', () => {
+			var source = new FakeEventTarget();
+
+			const expected = {};
+			drain(take(1, fromEvent('test', source, expected)));
+			source.emit('unused');
+
+			expect(source._capture).toBe(expected);
+		})
+
+		it('should pass false if capture not provided', () => {
+			var source = new FakeEventTarget();
+
+			drain(take(1, fromEvent('test', source)));
+			source.emit('unused');
+
+			expect(source._capture).toBe(false);
+		})
 	});
 
 	describe('given an EventEmitter', function() {


### PR DESCRIPTION
This aligns fromEvent's handling of the optional capture arg with [how `@most/dom-event` handles it](https://github.com/mostjs/dom-event/blob/master/src/dom-event.js#L8).  If it's not provide, it defaults to false.

Fix #288