### PR TITLE
Update symbol-observable 1.x usage

### DIFF
--- a/lib/observable/getObservable.js
+++ b/lib/observable/getObservable.js
@@ -2,7 +2,7 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-var symbolObservable = require('symbol-observable');
+var symbolObservable = require('symbol-observable').default;
 
 module.exports = getObservable;
 

--- a/most.js
+++ b/most.js
@@ -7,7 +7,7 @@ var base = require('@most/prelude');
 var core = require('./lib/source/core');
 var from = require('./lib/source/from').from;
 var periodic = require('./lib/source/periodic').periodic;
-var symbolObservable = require('symbol-observable');
+var symbolObservable = require('symbol-observable').default;
 
 /**
  * Core stream type
@@ -35,7 +35,7 @@ Stream.prototype.subscribe = function(subscriber) {
 
 Stream.prototype[symbolObservable] = function() {
 	return this;
-}
+};
 
 //-----------------------------------------------------------------------
 // Fluent adapter

--- a/test/combinator/continueWith-test.js
+++ b/test/combinator/continueWith-test.js
@@ -1,5 +1,5 @@
 import { spec, referee } from 'buster';
-const { describe, it } = spec
+const { describe, it } = spec;
 const { fail, assert } = referee;
 
 import { continueWith } from '../../lib/combinator/continueWith';

--- a/test/combinator/continueWith-test.js
+++ b/test/combinator/continueWith-test.js
@@ -8,8 +8,8 @@ import { of as just } from '../../lib/source/core';
 
 describe('continueWith', () => {
 	it('when f throws, should propagate error', () => {
-		const error = new Error()
-		const s = continueWith(x => { throw error; }, just(0));
+		const error = new Error();
+		const s = continueWith(() => { throw error; }, just(0));
 		return drain(s).then(fail, e => assert.same(error, e));
 	});
 });

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -1,57 +1,58 @@
-require('buster').spec.expose();
-var assert = require('buster').referee.assert;
+import { spec, referee } from 'buster';
+const { describe, it } = spec;
+const { assert } = referee;
 
-var most = require('../most');
-var symbolObservable = require('symbol-observable');
+import * as most from '../most';
+import symbolObservable from 'symbol-observable';
 
-describe('just', function() {
-	it('should be an alias for of', function() {
+describe('just', () => {
+	it('should be an alias for of', () => {
 		assert.isFunction(most.just);
 		assert.same(most.just, most.of);
 	});
 });
 
-describe('chain', function() {
-	it('should be an alias for flatMap', function() {
+describe('chain', () => {
+	it('should be an alias for flatMap', () => {
 		assert.isFunction(most.chain);
 		assert.same(most.chain, most.flatMap);
 		assert.same(most.Stream.prototype.chain, most.Stream.prototype.flatMap);
 	});
 });
 
-describe('forEach', function() {
-	it('should be an alias for observe', function() {
+describe('forEach', () => {
+	it('should be an alias for observe', () => {
 		assert.isFunction(most.forEach);
 		assert.same(most.forEach, most.observe);
 		assert.same(most.Stream.prototype.forEach, most.Stream.prototype.observe);
 	});
 });
 
-describe('takeUntil', function() {
-	it('should be an alias for until', function() {
+describe('takeUntil', () => {
+	it('should be an alias for until', () => {
 		assert.isFunction(most.takeUntil);
 		assert.same(most.takeUntil, most.until);
 		assert.same(most.Stream.prototype.takeUntil, most.Stream.prototype.until);
 	});
 });
 
-describe('skipUntil', function() {
-	it('should be an alias for since', function() {
+describe('skipUntil', () => {
+	it('should be an alias for since', () => {
 		assert.isFunction(most.skipUntil);
 		assert.same(most.skipUntil, most.since);
 		assert.same(most.Stream.prototype.skipUntil, most.Stream.prototype.since);
 	});
 });
 
-describe('flatMapEnd', function() {
-	it('should be an alias for continueWith', function() {
+describe('flatMapEnd', () => {
+	it('should be an alias for continueWith', () => {
 		assert.isFunction(most.flatMapEnd);
 		assert.same(most.flatMapEnd, most.continueWith);
 		assert.same(most.Stream.prototype.flatMapEnd, most.Stream.prototype.continueWith);
 	});
 
-	describe('flatMapError', function() {
-		it('should be an alias for recoverWith', function () {
+	describe('flatMapError', () => {
+		it('should be an alias for recoverWith', () => {
 			assert.isFunction(most.flatMapError);
 			assert.same(most.flatMapError, most.recoverWith);
 			assert.same(most.Stream.prototype.flatMapError, most.Stream.prototype.recoverWith);
@@ -59,15 +60,15 @@ describe('flatMapEnd', function() {
 	});
 });
 
-describe('multicast', function() {
-	it('should be a function', function() {
+describe('multicast', () => {
+	it('should be a function', () => {
 		assert.isFunction(most.multicast);
 		assert.isFunction(most.Stream.prototype.multicast);
 	});
 });
 
-describe('Draft ES Observable API interop', function() {
-	it('should exist', function() {
+describe('Draft ES Observable API interop', () => {
+	it('should exist', () => {
 		assert.isFunction(most.Stream.prototype.subscribe);
 		assert.isFunction(most.Stream.prototype[symbolObservable]);
 	});

--- a/test/observable/getObservable-test.js
+++ b/test/observable/getObservable-test.js
@@ -1,11 +1,12 @@
-require('buster').spec.expose();
-var assert = require('buster').referee.assert;
+import { spec, referee } from 'buster';
+const { describe, it } = spec;
+const { assert } = referee;
 
-var symbolObservable = require('symbol-observable');
-var getObservable = require('../../lib/observable/getObservable');
+import symbolObservable from 'symbol-observable'
+import getObservable from '../../lib/observable/getObservable';
 
 describe('getObservable', function() {
-	it('should return null for non-object', function() {
+	it('should return null for non-object', () => {
 		assert.same(null, getObservable(0));
 		assert.same(null, getObservable(1));
 		assert.same(null, getObservable(undefined));
@@ -15,42 +16,38 @@ describe('getObservable', function() {
 		assert.same(null, getObservable(false));
 	});
 
-	it('should return null for non-observable object', function() {
+	it('should return null for non-observable object', () => {
 		assert.same(null, getObservable({}));
 		assert.same(null, getObservable(null));
 		assert.same(null, getObservable(function() {}));
 		assert.same(null, getObservable([]));
 	});
 
-	it('should throw TypeError for invalid observable', function() {
-		var outer = {};
-		outer[symbolObservable] = function() {
-			return null;
-		}
+	it('should throw TypeError for invalid observable', () => {
+		const outer = {
+			[symbolObservable]: () => null
+		};
 
-		assert.exception(function() {
-			return getObservable(outer);
-		}, function(e) { return e instanceof TypeError });
+		assert.exception(() => getObservable(outer),
+			e => e instanceof TypeError);
 	});
 
-	it('should throw if calling Symbol.observable throws', function() {
-		var outer = {};
-		var error = new Error();
-		outer[symbolObservable] = function() {
-			throw error;
-		}
+	it('should throw if calling Symbol.observable throws', () => {
+		const error = new Error();
+		const outer = {
+			[symbolObservable] () {
+				throw error;
+			}
+		};
 
-		assert.exception(function() {
-			return getObservable(outer);
-		}, function(e) { return e === error });
+		assert.exception(() => getObservable(outer), e => e === error);
 	});
 
 	it('should return observable if valid', function() {
-		var outer = {};
-		var inner = { subscribe: function() {} };
-		outer[symbolObservable] = function() {
-			return inner
-		}
+		const inner = { subscribe: function() {} };
+		const outer = {
+			[symbolObservable]: () => inner
+		};
 
 		assert.same(inner, getObservable(outer));
 	});

--- a/test/observable/getObservable-test.js
+++ b/test/observable/getObservable-test.js
@@ -43,7 +43,7 @@ describe('getObservable', function() {
 		assert.exception(() => getObservable(outer), e => e === error);
 	});
 
-	it('should return observable if valid', function() {
+	it('should return observable if valid', () => {
 		const inner = { subscribe: function() {} };
 		const outer = {
 			[symbolObservable]: () => inner


### PR DESCRIPTION
From #293:

> So when the symbol-observable package went to 1.x, it was babel-ified and as such, any common JS reference needs to pull from default name space here:
> ...
> Just needs to be:
>
> var symbolObservable = require('symbol-observable').default;

Fix #293