### PR TITLE
Remove node 0.12 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "6"
   - "5"
   - "4"
-  - "0.12"
 env:
   - CXX=g++-4.8
 branches:


### PR DESCRIPTION
eslint 3 officially dropped support for node 0.12, so this PR drops node 0.12 from travis.  We *could* just decide not to lint on 0.12 and still run unit tests, but I like the simplicity of just moving on, especially since node 4 is LTS.