### PR TITLE
Fix typo in switch dispose.all setup

### DIFF
--- a/lib/combinator/switch.js
+++ b/lib/combinator/switch.js
@@ -23,7 +23,7 @@ function Switch(source) {
 
 Switch.prototype.run = function(sink, scheduler) {
 	var switchSink = new SwitchSink(sink, scheduler);
-	return dispose.all(switchSink, this.source.run(switchSink, scheduler));
+	return dispose.all([switchSink, this.source.run(switchSink, scheduler)]);
 };
 
 function SwitchSink(sink, scheduler) {
@@ -50,7 +50,7 @@ SwitchSink.prototype.error = function(t, e) {
 };
 
 SwitchSink.prototype.dispose = function() {
-	return this._disposeCurrent(0);
+	return this._disposeCurrent(this.scheduler.now());
 };
 
 SwitchSink.prototype._disposeCurrent = function(t) {

--- a/test/switch-test.js
+++ b/test/switch-test.js
@@ -1,86 +1,99 @@
-require('buster').spec.expose();
-var expect = require('buster').expect;
+import { spec, referee } from 'buster';
+const { describe, it } = spec;
+const { assert, refute } = referee;
 
-var switchLatest = require('../lib/combinator/switch').switch;
-var reduce = require('../lib/combinator/accumulate').reduce;
-var observe = require('../lib/combinator/observe').observe;
-var take = require('../lib/combinator/slice').take;
-var transform = require('../lib/combinator/transform');
-var periodic = require('../lib/source/periodic').periodic;
-var fromArray = require('../lib/source/fromArray').fromArray;
-var core = require('../lib/source/core');
-var Stream = require('../lib/Stream');
+import { switch as switchLatest } from '../lib/combinator/switch';
+import { observe } from '../lib/combinator/observe';
+import { take } from '../lib/combinator/slice';
+import { constant, map, tap } from '../lib/combinator/transform';
+import { periodic } from '../lib/source/periodic';
+import { fromArray } from '../lib/source/fromArray';
+import { empty, of as just } from '../lib/source/core';
 
-var te = require('./helper/testEnv');
+import te from './helper/testEnv';
 
-var constant = transform.constant;
-var map = transform.map;
-
-describe('switch', function() {
-	describe('when input is empty', function() {
-		it('should return empty', function() {
-			var spy = this.spy();
-			return observe(spy, switchLatest(core.empty()))
-				.then(function() {
-					expect(spy).not.toHaveBeenCalled();
-				});
+describe('switch', () => {
+	describe('when input is empty', () => {
+		// need this.spy, can't use arrow function
+ 		it('should return empty', function () {
+			const spy = this.spy();
+			return observe(spy, switchLatest(empty()))
+				.then(() => refute(spy.called));
 		});
 	});
 
-	describe('when input contains a single stream', function() {
-		it('should return an equivalent stream', function() {
-			var expected = [1, 2, 3];
-			var s = core.of(fromArray(expected));
+	it('should dispose penultimate stream when ending with empty', () => {
+		// If we spy on the stream and collect its events, we should end
+		// up seeing the same set of events as if we collect all the events
+		// that can be observed (i.e. by observe())
+		const events = [];
+		const push = x => events.push(x);
+		const toInner = x => x === 0
+			? switchLatest(map(just, tap(push, take(1, periodic(1, 1)))))
+			: empty();
 
-			return te.collectEvents(switchLatest(s), te.ticks(1)).then(function(events) {
-				expect(events).toEqual([
-					{ time: 0, value: 1 },
-					{ time: 0, value: 2 },
-					{ time: 0, value: 3 }
-				])
-			})
+		const s = switchLatest(map(toInner, fromArray([0,1])));
+		return te.collectEvents(s, te.ticks(10))
+			.then(evs => {
+				assert.equals(evs, events);
+			});
+	});
+
+	describe('when input contains a single stream', () => {
+		it('should return an equivalent stream', () => {
+			const expected = [1, 2, 3];
+			const s = just(fromArray(expected));
+
+			return te.collectEvents(switchLatest(s), te.ticks(1))
+				.then(events => {
+					assert.equals(events, [
+						{ time: 0, value: 1 },
+						{ time: 0, value: 2 },
+						{ time: 0, value: 3 }
+					]);
+				})
 		});
 	});
 
-	describe('when input contains many streams', function() {
-		describe('and all items are instantaneous', function() {
-			it('should be equivalent to the last inner stream', function() {
-				var expected = [1, 2, 3];
-				var s = fromArray([
+	describe('when input contains many streams', () => {
+		describe('and all items are instantaneous', () => {
+			it('should be equivalent to the last inner stream', () => {
+				const expected = [1, 2, 3];
+				const s = fromArray([
 					fromArray([4, 5, 6]),
 					fromArray(expected)
 				]);
 
-				return te.collectEvents(switchLatest(s), te.ticks(1)).then(function(events) {
-					expect(events).toEqual([
-						{ time: 0, value: 1 },
-						{ time: 0, value: 2 },
-						{ time: 0, value: 3 }
-					])
-				})
+				return te.collectEvents(switchLatest(s), te.ticks(1))
+					.then(events => {
+						assert.equals(events, [
+							{ time: 0, value: 1 },
+							{ time: 0, value: 2 },
+							{ time: 0, value: 3 }
+						]);
+					})
 			});
 		});
 
-		it('should switch when new stream arrives', function() {
-			var i = 0;
-			var s = map(function() {
-				return constant(++i, periodic(1));
-			}, periodic(3));
+		it('should switch when new stream arrives', () => {
+			let i = 0;
+			const s = map(() => constant(++i, periodic(1)), periodic(3));
 
-			return te.collectEvents(take(10, switchLatest(s)), te.ticks(250)).then(function(events) {
-				expect(events).toEqual([
-					{ time: 0, value: 1 },
-					{ time: 1, value: 1 },
-					{ time: 2, value: 1 },
-					{ time: 3, value: 2 },
-					{ time: 4, value: 2 },
-					{ time: 5, value: 2 },
-					{ time: 6, value: 3 },
-					{ time: 7, value: 3 },
-					{ time: 8, value: 3 },
-					{ time: 9, value: 4 },
-				]);
-			});
+			return te.collectEvents(take(10, switchLatest(s)), te.ticks(250))
+				.then(events => {
+					assert.equals(events, [
+						{ time: 0, value: 1 },
+						{ time: 1, value: 1 },
+						{ time: 2, value: 1 },
+						{ time: 3, value: 2 },
+						{ time: 4, value: 2 },
+						{ time: 5, value: 2 },
+						{ time: 6, value: 3 },
+						{ time: 7, value: 3 },
+						{ time: 8, value: 3 },
+						{ time: 9, value: 4 },
+					]);
+				});
 		});
 	});
 });


### PR DESCRIPTION
This fixes a fatal typo 😖 in the `switch` source code that caused disposing to fail.  The failure manifested under specific conditions (see #300).  Added a unit test that simulates those conditions.

This also adds a sane end time value, instead of `0`, and updates switch-test to ES6 source.

Fix #300 