### PR TITLE
Fixes most.d.ts merge, mergeArray definition

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -242,8 +242,15 @@ export function continueWith<A>(f: (a: any) => Stream<A>, s: Stream<A>): Stream<
 export function concatMap<A, B>(f: (a: A) => Stream<B>, s: Stream<A>): Stream<B>;
 export function mergeConcurrently<A>(concurrency: number, s: Stream<Stream<A>>): Stream<A>;
 
-export function merge<A>(...ss: Array<Stream<A>>): Stream<A>;
-export function mergeArray<A>(streams: Array<Stream<A>>): Stream<A>;
+export function merge<A, B>(...arr: Array<A | B>): Stream<A | B>;
+export function merge<A, B, C>(...arr: Array<A | B | C>): Stream<A | B | C>;
+export function merge<A, B, C, D>(...arr: Array<A | B | C | D>): Stream<A | B | C | D>;
+export function merge<A, B, C, D, E>(...arr: Array<A | B | C | D | E>): Stream<A | B | C | D | E>;
+
+export function mergeArray<A, B>(arr: Array<A | B>): Stream<A | B>;
+export function mergeArray<A, B, C>(arr: Array<A | B | C>): Stream<A | B | C>;
+export function mergeArray<A, B, C, D>(arr: Array<A | B | C | D>): Stream<A | B | C | D>;
+export function mergeArray<A, B, C, D, E>(arr: Array<A | B | C | D | E>): Stream<A | B | C | D | E>;
 
 export function combine<A, B, R>(
   fn: (a: A, b: B) => R,

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -242,15 +242,25 @@ export function continueWith<A>(f: (a: any) => Stream<A>, s: Stream<A>): Stream<
 export function concatMap<A, B>(f: (a: A) => Stream<B>, s: Stream<A>): Stream<B>;
 export function mergeConcurrently<A>(concurrency: number, s: Stream<Stream<A>>): Stream<A>;
 
-export function merge<A, B>(...arr: Array<A | B>): Stream<A | B>;
-export function merge<A, B, C>(...arr: Array<A | B | C>): Stream<A | B | C>;
-export function merge<A, B, C, D>(...arr: Array<A | B | C | D>): Stream<A | B | C | D>;
-export function merge<A, B, C, D, E>(...arr: Array<A | B | C | D | E>): Stream<A | B | C | D | E>;
+export interface Merge {
+    <A>(stream: Stream<A>): Stream<A>;
+    <A, B>(stream1: Stream<A>, stream2: Stream<B>): Stream<A | B>;
+    <A, B, C>(stream1: Stream<A>, stream2: Stream<B>, stream3: Stream<C>): Stream<A | B | C>;
+    <A, B, C, D>(stream1: Stream<A>, stream2: Stream<B>, stream3: Stream<C>, stream4: Stream<D>): Stream<A | B | C | D>;
+    <A, B, C, D, E>(stream1: Stream<A>, stream2: Stream<B>, stream3: Stream<C>, stream4: Stream<D>): Stream<A | B | C | D | E>;
+}
 
-export function mergeArray<A, B>(arr: Array<A | B>): Stream<A | B>;
-export function mergeArray<A, B, C>(arr: Array<A | B | C>): Stream<A | B | C>;
-export function mergeArray<A, B, C, D>(arr: Array<A | B | C | D>): Stream<A | B | C | D>;
-export function mergeArray<A, B, C, D, E>(arr: Array<A | B | C | D | E>): Stream<A | B | C | D | E>;
+export const merge: Merge;
+
+export interface MergeArray {
+    <A>(arr: [Stream<A>]): Stream<A>;
+    <A, B>(arr: [Stream<A>, Stream<B>]): Stream<A | B>;
+    <A, B, C>(arr: [Stream<A>, Stream<B>, Stream<C>]): Stream<A | B | C>;
+    <A, B, C, D>(arr: [Stream<A>, Stream<B>, Stream<C>, Stream<D>]): Stream<A | B | C | D>;
+    <A, B, C, D, E>(arr: [Stream<A>, Stream<B>, Stream<C>, Stream<D>, Stream<E>]): Stream<A | B | C | D | E>;
+}
+
+export const mergeArray: MergeArray;
 
 export function combine<A, B, R>(
   fn: (a: A, b: B) => R,


### PR DESCRIPTION
The current definition restricts only single generic type of A. `merge` in most is a stream that can be a stream of multiple value types. i.e. `Stream<A | B>` or `Stream<A | B | C>` etc..

Right now this PR it is limited to to up to 5 types.

Note: Most does not restrict merge with a single parameter(`most.merge(stream)`) in javascript this is just fine. but this will fail in typescript since we typed it to either 2 or more types. i think this is negligible so i didn't bother.


@briancavalier i can provide examples if this is not well understood