### PR TITLE
Fix `Iterable` interface

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -2,7 +2,7 @@ declare type SeedValue<S, V> = { seed: S, value: V };
 declare type TimeValue<V>    = { time: number, value: V };
 
 declare interface Generator<A, B, C> {}
-declare interface Iterable<A> {}
+declare interface Iterable<A> { [Symbol.iterator](): IterableIterator<A>; }
 
 declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A>, any, any>;
 

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -2,7 +2,7 @@ declare type SeedValue<S, V> = { seed: S, value: V };
 declare type TimeValue<V>    = { time: number, value: V };
 
 declare interface Generator<A, B, C> {}
-declare interface Iterable<A> { [Symbol.iterator](): IterableIterator<A>; }
+declare interface Iterable<A> { [Symbol.iterator](): IterableIterator<A> }
 
 declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A>, any, any>;
 


### PR DESCRIPTION
The interface for `Iterable` was empty.

When writing something like `most.from([1,2,3])` the result was typed `Stream<{}>` instead of `Stream<number>`.

This pull request fixes cases like that.

Originally I only accounted for arrays with:

```
declare interface Iterable<A> { [key: number]: A; }
```

but, by definition, `Symbol.iterator` is probably more suitable for _Iterators_.
