### PR TITLE
Type correction fromEvent most.d.ts

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -220,7 +220,7 @@ export function empty(): Stream<any>;
 export function never(): Stream<any>;
 export function from<A>(as: Iterable<A>): Stream<A>;
 export function periodic<A>(period: number, a?: A): Stream<A>;
-export function fromEvent(event: string, target: any, useCapture?: boolean): Stream<Event>;
+export function fromEvent<T extends Event>(event: string, target: any, useCapture?: boolean): Stream<T>;
 
 export function unfold<A, B, S>(f: (seed: S) => SeedValue<S, B|Promise<B>>, seed: S): Stream<B>;
 export function iterate<A>(f: (a: A) => A|Promise<A>, a: A): Stream<A>;


### PR DESCRIPTION
To get the proper type you have to overwrite whole expression. this fix gives the ability to manually cast type that has to satisfy  the constraint of 'Event'.

````typescript
fromEvent('mousemove', document.body) // evaluates type of Stream<Event>

fromEvent<MouseEvent>('mousemove', document.body) // evaluates type of Stream<MouseEvent>

fromEvent<CSSStyleDeclaration>('mousemove', document.body) // error [ts] Type 'CSSStyleDeclaration' does not satisfy the constraint 'Event'
````