### PR TITLE
should noop when it's already disposed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,6 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
+indent_size = 2
 end_of_line = LF

--- a/src/observable/subscribe.js
+++ b/src/observable/subscribe.js
@@ -26,7 +26,7 @@ export function SubscribeObserver (fatalError, subscriber, disposable) {
 }
 
 SubscribeObserver.prototype.event = function (t, x) {
-  if (typeof this.subscriber.next === 'function') {
+  if (!this.disposable.disposed && typeof this.subscriber.next === 'function') {
     this.subscriber.next(x)
   }
 }

--- a/test/observable/subscribe-test.js
+++ b/test/observable/subscribe-test.js
@@ -54,11 +54,6 @@ describe('SubscribeObserver', function () {
       assert.same(undefined, so.event(1, 1))
     })
 
-    it('should be noop when its disposed', function () {
-      var so = new SubscribeObserver(fail, { next: fail }, { disposed: true })
-      assert.same(undefined, so.event(1, 1))
-    })
-
     it('should call subscriber.next if present', function () {
       var events = []
       var subscriber = {

--- a/test/observable/subscribe-test.js
+++ b/test/observable/subscribe-test.js
@@ -54,6 +54,11 @@ describe('SubscribeObserver', function () {
       assert.same(undefined, so.event(1, 1))
     })
 
+    it('should be noop when its disposed', function () {
+      var so = new SubscribeObserver(fail, { next: fail }, { disposed: true })
+      assert.same(undefined, so.event(1, 1))
+    })
+
     it('should call subscriber.next if present', function () {
       var events = []
       var subscriber = {

--- a/test/observable/unsubscribe-test.js
+++ b/test/observable/unsubscribe-test.js
@@ -1,0 +1,20 @@
+import { spec, referee } from 'buster'
+const { describe, it } = spec
+const { fail, assert } = referee
+
+import { fromArray } from '../../src/source/fromArray'
+import { map } from '../../src/combinator/transform'
+import { subscribe } from '../../src/observable/subscribe'
+
+describe('unsubscribe', () => {
+  it('should prevent observation after unsubscribe', done => {
+    const f = x => {
+      assert.same(1, x)
+      subscription.unsubscribe()
+      done()
+    }
+
+    const subscriber = { next: fail, error: fail, complete: fail }
+    let subscription = subscribe(subscriber, map(f, fromArray([1, 2])))
+  })
+})


### PR DESCRIPTION
by simply walk around the codebase

i think this is propbaly the fix for issue #360

by checking `disposable.disposed` before calling the `next` callback

thoughts? @briancavalier