### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,21 +45,21 @@
   "license": "MIT",
   "devDependencies": {
     "@most/eslint-config-most": "^1.0.3",
-    "@most/hold": "^1.3.1",
-    "babel-polyfill": "^6.13.0",
-    "buba": "3.0.1",
+    "@most/hold": "1.4.2",
+    "babel-polyfill": "^6.20.0",
+    "buba": "^4.0.1",
     "buster": "^0.7.18",
-    "eslint": "^3.4.0",
-    "markdown-doctest": "^0.9.0",
+    "eslint": "^3.12.1",
+    "markdown-doctest": "^0.9.1",
     "rimraf": "^2.5.4",
-    "rollup": "^0.36.0",
-    "rollup-plugin-buble": "^0.13.0",
+    "rollup": "^0.37.0",
+    "rollup-plugin-buble": "^0.14.0",
     "rollup-plugin-node-resolve": "^2.0.0",
     "transducers-js": "^0.4.174",
-    "uglify-js": "^2.7.3"
+    "uglify-js": "^2.7.5"
   },
   "dependencies": {
-    "@most/multicast": "^1.2.3",
+    "@most/multicast": "^1.2.5",
     "@most/prelude": "^1.4.0",
     "symbol-observable": "^1.0.2"
   }


### PR DESCRIPTION
Update all deps except `@most/hold`. Lock `@most/hold` to 1.4.2 to avoid markdown-doctest+babel incompat which is breaking the build.  This is a temporary lock until we decide how to deal with `@most/hold`.

Close #364 
Close #329 