### PR TITLE
feat(count): implement count combinator

### DIFF
--- a/src/combinator/count.js
+++ b/src/combinator/count.js
@@ -1,0 +1,36 @@
+import Pipe from '../sink/Pipe'
+import PropagateTask from '../scheduler/PropagateTask'
+import { all } from '../disposable/dispose'
+
+export function count (stream) {
+  return new stream.constructor(new Count(stream.source))
+}
+
+class Count {
+  constructor (source) {
+    this.source = source
+  }
+
+  run (sink, scheduler) {
+    const initial = scheduler.asap(PropagateTask.event(0, sink))
+    const disposable = this.source.run(new CountSink(sink), scheduler)
+
+    return all([initial, disposable])
+  }
+}
+
+class CountSink extends Pipe {
+  constructor (sink) {
+    super(sink)
+    this.count = 0
+  }
+
+  event (t, x) {
+    ++this.count
+    this.sink.event(t, this.count)
+  }
+
+  end (t, x) {
+    this.sink.end(t, this.count)
+  }
+}

--- a/test/combinator/count-test.js
+++ b/test/combinator/count-test.js
@@ -1,0 +1,17 @@
+import { spec, referee } from 'buster'
+const { describe, it } = spec
+const { assert } = referee
+
+import { count } from '../../src/combinator/count'
+import { drain } from '../../src/combinator/observe'
+import { from } from '../../src/source/from'
+
+describe('count', () => {
+  it('counts the number of emitted values', () => {
+    const stream = count(from([null, null, null]))
+
+    return drain(stream).then(x => {
+      assert.same(x, 3)
+    })
+  })
+})


### PR DESCRIPTION
As per some previous discussion with @briancavalier  and @davidchase  on a primitive that allows keeping a number representation of the amount of events that a stream has emitted, here is an initial implementation of `count`. This is to serve as a place to continue discussion around such an operator.

If/when agreed upon -- Things that need doing

- [ ] Write documentation
- [ ] Publicly export the combinator
- [ ] Add combinator to the Stream prototype
- [ ] Add to TypeScript type definitions