### PR TITLE
Fix xstream switch perf test

### DIFF
--- a/test/perf/package.json
+++ b/test/perf/package.json
@@ -14,8 +14,9 @@
     "scan": "node ./scan.js",
     "slice": "node ./slice.js",
     "skipRepeats": "node ./skipRepeats.js",
+    "switch": "node ./switch.js",
     "zip": "node ./zip.js",
-    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats"
+    "start": "npm run filter-map-reduce && npm run flatMap && npm run concatMap && npm run merge && npm run merge-nested && npm run zip && npm run scan && npm run slice && npm run skipRepeats && npm run switch"
   },
   "dependencies": {
     "@reactivex/rxjs": "^5.0.1",

--- a/test/perf/switch.js
+++ b/test/perf/switch.js
@@ -59,7 +59,7 @@ suite
         function(x) {return rx.Observable.fromArray(x)}).reduce(sum, 0));
   }, options)
   .add('xstream', function(deferred) {
-    runners.runXstream(deferred, xs.fromArray(a).map(bacon.fromArray).flatten().fold(sum, 0).last());
+    runners.runXstream(deferred, xs.fromArray(a).map(xs.fromArray).flatten().fold(sum, 0).last());
   }, options)
   .add('kefir', function(deferred) {
     runners.runKefir(deferred, kefirFromArray(a).flatMapLatest(kefirFromArray).scan(sum, 0).last());


### PR DESCRIPTION
Also, add switch test to the full perf test run.  ht @davidchase for [finding the mistake](https://github.com/mostjs/core/pull/2#issuecomment-269335352) that was preventing the xstream test from running.