### PR TITLE
Fix typing of sampleWith combinator

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -174,7 +174,7 @@ export interface Stream<A> {
     e: Stream<E>
   ): Stream<R>;
 
-  sampleWith<A>(sampler: Stream<any>): Stream<A>;
+  sampleWith(sampler: Stream<any>): Stream<A>;
 
   zip<B, R>(
     fn: (a: A, b: B) => R,


### PR DESCRIPTION
sampleWith's output type should be the same as the stream that is being consumed. The extra type parameter allowed for any type - removing the generic fixes the typings.