### PR TITLE
Deprecate end/complete value parameter where applicable

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -342,7 +342,7 @@ The unfolding function accepts a seed value and must return a tuple: `{value:*, 
 * `tuple.value` will be emitted as an event.
 * `tuple.seed` will be passed to the next invocation of the unfolding function.
 * `tuple.done` can be used to stop unfolding.  When `tuple.done == true`, unfolding will stop.  Additionally, when `tuple.done == true`:
-	* `tuple.value` will be used as the stream's end signal value.  It *will not* appear as a normal event in the stream.
+	* `tuple.value` **(deprecated)** will be used as the stream's end signal value.  In future versions, `tuple.value` will be *ignored* when `tuple.done` is `true`
  	* `tuple.seed` will be ignored
 
 Note that if the unfolding function never returns a tuple with `tuple.done == true`, the stream will be infinite.
@@ -1102,8 +1102,9 @@ type Observer = {
   next(value) => void
   // Receives the sequence error
   error(errorValue) => void
-  // Receives the sequence completion value
-  complete(completeValue) => void
+  // Receives the sequence completion signal
+  // The completionValue parameter is deprecated
+  complete(completionValue) => void
 }
 ```
 

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -8,6 +8,7 @@ declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A
 
 export interface Sink<A> {
   event(time: number, value: A): void;
+  // end value parameter is deprecated
   end(time: number, value?: A): void;
   error(time: number, err: Error): void;
 }
@@ -46,6 +47,7 @@ export interface Source<A> {
 export interface Subscriber<A> {
   next(value: A): void;
   error(err: Error): void;
+  // complete value parameter is deprecated
   complete(value?: A): void;
 }
 
@@ -405,6 +407,7 @@ export class PropagateTask<T> implements Task {
 
 	static event <T> (value: T, sink: Sink<T>): PropagateTask<T>;
 	static error (error: Error, sink: Sink<any>): PropagateTask<any>;
+  // end value parameter is deprecated
 	static end <T> (value: T, sink: Sink<T>): PropagateTask<T>;
 
 	run(time: number): void;


### PR DESCRIPTION
It's proven to be basically useless in practice.  Also, the ES Observable proposal, which includes the an end value, has gotten more complicated, which makes the simplicity of [Fantasy Observable](https://github.com/staltz/fantasy-observable), which doesn't have an end value, much more appealing.