### PR TITLE
ES5 compatibility in ES2015 module build

### DIFF
--- a/src/source/fromIterable.js
+++ b/src/source/fromIterable.js
@@ -19,7 +19,7 @@ IterableSource.prototype.run = function (sink, scheduler) {
 }
 
 function runProducer (t, iterator, sink) {
-  let r = iterator.next()
+  var r = iterator.next()
 
   while (!r.done && this.active) {
     sink.event(t, r.value)


### PR DESCRIPTION
Using Webpack 2 to compile an application using `most`, the minification step generates this error:

```bash
ERROR in my_app.js from UglifyJs
SyntaxError: Unexpected token: name (r) [./~/most/src/source/fromIterable.js:22,0][my_app.js:6294,6]
```

```javascript
function runProducer (t, iterator, sink) {
  let r = iterator.next()
      ^
  // ...
}

```

The generated bundle would also fail in browsers that don't support ES6 because of the `let` keyword.

Webpack 2 uses the value of the `module` key in `package.json` to resolve the `most` package with ES2015 modules, so it can apply tree shaking. In `most`, this is just the plain source code in `most/src`.

In the package `module` points to, [all other statements than `import` and `export` should be usable in the environments `most` wants to support](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features). To support ES5, we need to use `var` instead of `let` here. This was the only use of `let` I found in the source code, other than a couple ones in the tests which doesn't matter for app bundle compilation.

This pull request changes that one `let` to `var`.

If you guys are planning to use more ES6 features in the codebase, a separate build is probably needed that transpiles to ES5 (or whatever `most` wants to support), but doesn't transpile the `import` and `export` statements so that bundlers can take advantage of tree shaking.