### PR TITLE
fix(fromObservable): allow proper error handling

### DIFF
--- a/src/observable/fromObservable.js
+++ b/src/observable/fromObservable.js
@@ -4,6 +4,7 @@
 
 import Stream from '../Stream'
 import * as dispose from '../disposable/dispose'
+import { tryEnd, tryEvent } from '../source/tryEvent'
 
 export function fromObservable (observable) {
   return new Stream(new ObservableSource(observable))
@@ -30,11 +31,11 @@ export function SubscriberSink (sink, scheduler) {
 }
 
 SubscriberSink.prototype.next = function (x) {
-  this.sink.event(this.scheduler.now(), x)
+  tryEvent(this.scheduler.now(), x, this.sink)
 }
 
 SubscriberSink.prototype.complete = function (x) {
-  this.sink.end(this.scheduler.now(), x)
+  tryEnd(this.scheduler.now(), x, this.sink)
 }
 
 SubscriberSink.prototype.error = function (e) {

--- a/test/observable/fromObservable-test.js
+++ b/test/observable/fromObservable-test.js
@@ -3,7 +3,9 @@ require('buster').spec.expose()
 var assert = require('buster').referee.assert
 
 var reduce = require('../../src/combinator/accumulate').reduce
+var map = require('../../src/combinator/transform').map
 var fo = require('../../src/observable/fromObservable')
+var subscribe = require('../../src/observable/subscribe').subscribe
 var fromObservable = fo.fromObservable
 var ObservableSource = fo.ObservableSource
 var SubscriberSink = fo.SubscriberSink
@@ -28,6 +30,30 @@ describe('fromObservable', function () {
       .then(function (a) {
         assert.equals(events, a)
       })
+  })
+
+  it('should handle thrown errors', function (done) {
+    var o = simpleObservable(function (observer) {
+      observer.next(1)
+
+      return function () {}
+    })
+
+    function boom () {
+      throw new Error('boom!')
+    }
+
+    assert.equals(true, true) // buster requires an assertion
+
+    var s = map(boom, fromObservable(o))
+
+    subscribe({
+      next () { done(new Error('next should not be called')) },
+
+      error () { done() },
+
+      complete () { done(new Error('complete should not be called')) }
+    }, s)
   })
 })
 


### PR DESCRIPTION
Currently there is no error handling around `fromObservable` and can cause errors to be thrown in place rather than through most's sinks to be handled via `recoverWith` etc.

Fixes #407 