### PR TITLE
Remove `extends Event` constraint for `fromEvent`

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -227,6 +227,7 @@ export function never(): Stream<any>;
 export function from<A>(as: ArrayLike<A> | Iterable<A> | Observable<A>): Stream<A>;
 export function periodic<A>(period: number, a?: A): Stream<A>;
 export function fromEvent<T extends Event>(event: string, target: any, useCapture?: boolean): Stream<T>;
+export function fromEvent<T>(event: string, target: any): Stream<T>;
 
 export function unfold<A, B, S>(f: (seed: S) => SeedValue<S, B|Promise<B>>, seed: S): Stream<B>;
 export function iterate<A>(f: (a: A) => A|Promise<A>, a: A): Stream<A>;


### PR DESCRIPTION
The constraint `T extends Event` doesn't account for node.js EventEmitter's which are clearly [accounted for in the implementation](https://github.com/cujojs/most/blob/7d27cd50afa2cacb6ee39fc62b424c73d61fe9e5/src/source/fromEvent.js#L27-L28).

I've added it as an overload to further clarify that in those situations the `useCapture` parameter is not used.