### PR TITLE
Added spreadable overload for `sample`

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -179,6 +179,10 @@ export interface Stream<A> {
     d: Stream<D>,
     e: Stream<E>
   ): Stream<R>;
+  sample<B,R>(
+    fn: (...values: B[]) => R,
+    ...streams: Stream<B>[]
+  ): Stream<R>;
 
   sampleWith(sampler: Stream<any>): Stream<A>;
 
@@ -362,6 +366,11 @@ export function sample<A, B, C, D, E, R>(
   c: Stream<C>,
   d: Stream<D>,
   e: Stream<E>
+): Stream<R>;
+export function sample<A, R>(
+  fn: (...values: A[]) => R,
+  sampler: Stream<any>,
+  ...streams: Stream<A>[]
 ): Stream<R>;
 
 export function sampleWith<A>(sampler: Stream<any>, s: Stream<A>): Stream<A>;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -162,26 +162,29 @@ export interface Stream<A> {
   await<B>(): Stream<B>;
 
   sample<B, C, R>(
-    fn: (b: B, c: C) => R,
-    b: Stream<B>,
-    c: Stream<C>
-  ): Stream<R>;
-  sample<B, C, D, R>(
-    fn: (b: B, c: C, d: D) => R,
+    fn: (b: B, c: C, ...values: V[]) => R,
     b: Stream<B>,
     c: Stream<C>,
-    d: Stream<D>
+    ...streams: Stream<V>[]
   ): Stream<R>;
-  sample<B, C, D, E, R>(
-    fn: (b: B, c: C, d: D, e: E) => R,
+  sample<B, C, D, R>(
+    fn: (b: B, c: C, d: D, ...values: V[]) => R,
     b: Stream<B>,
     c: Stream<C>,
     d: Stream<D>,
-    e: Stream<E>
+    ...streams: Stream<V>[]
+  ): Stream<R>;
+  sample<B, C, D, E, R>(
+    fn: (b: B, c: C, d: D, e: E, ...values: V[]) => R,
+    b: Stream<B>,
+    c: Stream<C>,
+    d: Stream<D>,
+    e: Stream<E>,
+    ...streams: Stream<V>[]
   ): Stream<R>;
   sample<B,R>(
-    fn: (...values: B[]) => R,
-    ...streams: Stream<B>[]
+    fn: (...values: V[]) => R,
+    ...streams: Stream<V>[]
   ): Stream<R>;
 
   sampleWith(sampler: Stream<any>): Stream<A>;


### PR DESCRIPTION
This change adds a spreadable overload for `sample`.

This allows an arbitrary number of streams (more than the 2-5 currently typed) to be sampled, which [matches the implementation](https://github.com/cujojs/most/blob/ef629f5efd05569a0ef3a2eb1b981e01aab29574/docs/api.md#sample).

If you have an array of streams with a common type, you can also spread that into the call and expect typing to flow through.