### PR TITLE
Added spreadability to `sample`

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -161,23 +161,30 @@ export interface Stream<A> {
   // Note: Without higher-kinded types, this type cannot be written properly
   await<B>(): Stream<B>;
 
-  sample<B, C, R>(
-    fn: (b: B, c: C) => R,
-    b: Stream<B>,
-    c: Stream<C>
-  ): Stream<R>;
-  sample<B, C, D, R>(
-    fn: (b: B, c: C, d: D) => R,
+  sample<B, C, V, R>(
+    fn: (b: B, c: C, ...values: V[]) => R,
     b: Stream<B>,
     c: Stream<C>,
-    d: Stream<D>
+    ...streams: Stream<V>[]
   ): Stream<R>;
-  sample<B, C, D, E, R>(
-    fn: (b: B, c: C, d: D, e: E) => R,
+  sample<B, C, D, V, R>(
+    fn: (b: B, c: C, d: D, ...values: V[]) => R,
     b: Stream<B>,
     c: Stream<C>,
     d: Stream<D>,
-    e: Stream<E>
+    ...streams: Stream<V>[]
+  ): Stream<R>;
+  sample<B, C, D, E, V, R>(
+    fn: (b: B, c: C, d: D, e: E, ...values: V[]) => R,
+    b: Stream<B>,
+    c: Stream<C>,
+    d: Stream<D>,
+    e: Stream<E>,
+    ...streams: Stream<V>[]
+  ): Stream<R>;
+  sample<V, R>(
+    fn: (...values: V[]) => R,
+    ...streams: Stream<V>[]
   ): Stream<R>;
 
   sampleWith(sampler: Stream<any>): Stream<A>;
@@ -333,35 +340,44 @@ export function delay<A>(dt: number, s: Stream<A>): Stream<A>;
 export function fromPromise<A>(p: Promise<A>): Stream<A>;
 export function await<A>(s: Stream<Promise<A>>): Stream<A>;
 
-export function sample<A, B, R>(
-  fn: (a: A, b: B) => R,
-  sampler: Stream<any>,
-  a: Stream<A>,
-  b: Stream<B>
-): Stream<R>;
-export function sample<A, B, C, R>(
-  fn: (a: A, b: B, c: C) => R,
+export function sample<A, B, V, R>(
+  fn: (a: A, b: B, ...values: V[]) => R,
   sampler: Stream<any>,
   a: Stream<A>,
   b: Stream<B>,
-  c: Stream<C>
+  ...streams: Stream<V>[]
 ): Stream<R>;
-export function sample<A, B, C, D, R>(
-  fn: (a: A, b: B, c: C, d: D) => R,
+export function sample<A, B, C, V, R>(
+  fn: (a: A, b: B, c: C, ...values: V[]) => R,
   sampler: Stream<any>,
   a: Stream<A>,
   b: Stream<B>,
   c: Stream<C>,
-  d: Stream<D>
+  ...streams: Stream<V>[]
 ): Stream<R>;
-export function sample<A, B, C, D, E, R>(
-  fn: (a: A, b: B, c: C, d: D, e: E) => R,
+export function sample<A, B, C, D, V, R>(
+  fn: (a: A, b: B, c: C, d: D, ...values: V[]) => R,
   sampler: Stream<any>,
   a: Stream<A>,
   b: Stream<B>,
   c: Stream<C>,
   d: Stream<D>,
-  e: Stream<E>
+  ...streams: Stream<V>[]
+): Stream<R>;
+export function sample<A, B, C, D, E, V, R>(
+  fn: (a: A, b: B, c: C, d: D, e: E, ...values: V[]) => R,
+  sampler: Stream<any>,
+  a: Stream<A>,
+  b: Stream<B>,
+  c: Stream<C>,
+  d: Stream<D>,
+  e: Stream<E>,
+  ...streams: Stream<V>[]
+): Stream<R>;
+export function sample<V, R>(
+  fn: (...values: V[]) => R,
+  sampler: Stream<any>,
+  ...streams: Stream<V>[]
 ): Stream<R>;
 
 export function sampleWith<A>(sampler: Stream<any>, s: Stream<A>): Stream<A>;


### PR DESCRIPTION
This change adds a spreadable overload for `sample`.

This allows an arbitrary number of streams (more than the 2-5 currently typed) to be sampled, which [matches the implementation](https://github.com/cujojs/most/blob/ef629f5efd05569a0ef3a2eb1b981e01aab29574/docs/api.md#sample).

If you have an array of streams with a common type, you can also spread that into the call and expect typing to flow through.

Further, I've added spreadability to all overloads as there can commonly be scenarios where you want to sample distinct streams and then a bunch of common streams.