### PR TITLE
feat(Stream): add delegating run method

### DIFF
--- a/src/Stream.js
+++ b/src/Stream.js
@@ -5,3 +5,7 @@
 export default function Stream (source) {
   this.source = source
 }
+
+Stream.prototype.run = function (sink, source) {
+  return this.source.run(sink, source)
+}

--- a/test/Stream-test.js
+++ b/test/Stream-test.js
@@ -1,14 +1,39 @@
-/* global describe, it */
-require('buster').spec.expose()
-var expect = require('buster').expect
+import { spec, referee } from 'buster'
+const { describe, it } = spec
+const { assert } = referee
 
-var Stream = require('../src/Stream').default
+import Stream from '../src/Stream'
 
-var sentinel = { value: 'sentinel' }
+const sentinel = { value: 'sentinel' }
 
 describe('Stream', function () {
   it('should have expected source', function () {
-    var s = new Stream(sentinel)
-    expect(s.source).toBe(sentinel)
+    const s = new Stream(sentinel)
+    assert.same(sentinel, s.source)
+  })
+
+  describe('run', () => {
+    it('should delegate to source', () => {
+      const source = {
+        run: function (sink, scheduler) {
+          return {
+            sink, scheduler,
+            dispose () {
+              return Promise.resolve(sentinel)
+            }
+          }
+        }
+      }
+
+      const s = new Stream(source)
+
+      const sink = {}
+      const scheduler = {}
+      const d = s.run(sink, scheduler)
+
+      assert.same(sink, d.sink)
+      assert.same(scheduler, d.scheduler)
+      return d.dispose().then(result => assert.same(sentinel, result))
+    })
   })
 })

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -59,7 +59,7 @@ export interface Subscription<A> {
   unsubscribe(): void;
 }
 
-export interface Stream<A> {
+export interface Stream<A> extends Source<A> {
   reduce<B>(f: (b: B, a: A) => B, b: B): Promise<B>;
   observe(f: (a: A) => any): Promise<any>;
   forEach(f: (a: A) => any): Promise<any>;


### PR DESCRIPTION
Add delegating run() prototype method in preparation for compatibility with upcoming @most/core changes.  It simply delegates to the stream's source.

### Todo

- [x] corresponding TS def changes