### PR TITLE
fix(take): Fix take double dispose

### DIFF
--- a/src/combinator/slice.js
+++ b/src/combinator/slice.js
@@ -5,7 +5,6 @@
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
 import * as core from '../source/core'
-import * as dispose from '../disposable/dispose'
 import Map from '../fusion/Map'
 
 /**
@@ -61,20 +60,20 @@ function Slice (min, max, source) {
 }
 
 Slice.prototype.run = function (sink, scheduler) {
-  return new SliceSink(this.min, this.max - this.min, this.source, sink, scheduler)
+  return this.source.run(new SliceSink(this.min, this.max - this.min, sink), scheduler)
 }
 
-function SliceSink (skip, take, source, sink, scheduler) {
+function SliceSink (skip, take, sink) {
   this.sink = sink
   this.skip = skip
   this.take = take
-  this.disposable = dispose.once(source.run(this, scheduler))
 }
 
 SliceSink.prototype.end = Pipe.prototype.end
 SliceSink.prototype.error = Pipe.prototype.error
 
-SliceSink.prototype.event = function (t, x) { // eslint-disable-line complexity
+SliceSink.prototype.event = function (t, x) {
+  /* eslint complexity: [1, 4] */
   if (this.skip > 0) {
     this.skip -= 1
     return
@@ -91,10 +90,6 @@ SliceSink.prototype.event = function (t, x) { // eslint-disable-line complexity
   }
 }
 
-SliceSink.prototype.dispose = function () {
-  this.disposable.dispose()
-}
-
 export function takeWhile (p, stream) {
   return new Stream(new TakeWhile(p, stream.source))
 }
@@ -105,14 +100,13 @@ function TakeWhile (p, source) {
 }
 
 TakeWhile.prototype.run = function (sink, scheduler) {
-  return new TakeWhileSink(this.p, this.source, sink, scheduler)
+  return this.source.run(new TakeWhileSink(this.p, sink), scheduler)
 }
 
-function TakeWhileSink (p, source, sink, scheduler) {
+function TakeWhileSink (p, sink) {
   this.p = p
   this.sink = sink
   this.active = true
-  this.disposable = dispose.once(source.run(this, scheduler))
 }
 
 TakeWhileSink.prototype.end = Pipe.prototype.end
@@ -130,10 +124,6 @@ TakeWhileSink.prototype.event = function (t, x) {
   } else {
     this.sink.end(t, x)
   }
-}
-
-TakeWhileSink.prototype.dispose = function () {
-  return this.disposable.dispose()
 }
 
 export function skipWhile (p, stream) {

--- a/src/combinator/slice.js
+++ b/src/combinator/slice.js
@@ -87,13 +87,12 @@ SliceSink.prototype.event = function (t, x) { // eslint-disable-line complexity
   this.take -= 1
   this.sink.event(t, x)
   if (this.take === 0) {
-    this.dispose()
     this.sink.end(t, x)
   }
 }
 
 SliceSink.prototype.dispose = function () {
-  return this.disposable.dispose()
+  this.disposable.dispose()
 }
 
 export function takeWhile (p, stream) {
@@ -129,7 +128,6 @@ TakeWhileSink.prototype.event = function (t, x) {
   if (this.active) {
     this.sink.event(t, x)
   } else {
-    this.dispose()
     this.sink.end(t, x)
   }
 }


### PR DESCRIPTION
<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

Prevent `take` and `takeWhile` from disposing twice when they end the stream early.

SliceSink was explicitly calling dispose and `sink.end`.  However, `sink.end` also always [leads to dispose in runSource](https://github.com/cujojs/most/blob/master/src/runSource.js#L39).  Hence, dispose was being called twice.  This was partially hidden by the fact that SliceSink used `dispose.once` to "memoize" the effect of the disposable it was holding.

This fix has the added benefit of allowing SliceSink and TakeWhileSink to follow the more standard "just wrap the incoming sink" pattern, rather than having the additional responsibility to activate the source and manage the returned Disposable.

Fix #426
