### PR TITLE
Improve the checking of subscriber objects to match RxJS and zen-observable (#445)

### DIFF
--- a/src/observable/subscribe.js
+++ b/src/observable/subscribe.js
@@ -7,7 +7,7 @@ import * as dispose from '../disposable/dispose'
 import fatalError from '../fatalError'
 
 export function subscribe (subscriber, stream) {
-  if (subscriber == null || typeof subscriber !== 'object') {
+  if (Object(subscriber) !== subscriber) {
     throw new TypeError('subscriber must be an object')
   }
 

--- a/test/observable/subscribe-test.js
+++ b/test/observable/subscribe-test.js
@@ -12,7 +12,7 @@ var SubscribeObserver = s.SubscribeObserver
 var Subscription = s.Subscription
 
 describe('subscribe', function () {
-  it('should return { unsubscribe: () => void }', function () {
+  it('should return { unsubscribe: () => void } when passed an object', function () {
     var subscription = subscribe({}, empty())
 
     refute.same(null, subscription)
@@ -22,7 +22,17 @@ describe('subscribe', function () {
     assert.same(undefined, subscription.unsubscribe())
   })
 
-  it('should throw TypeError if subscriber not an object', function () {
+  it('should return { unsubscribe: () => void } when passed a function', function () {
+    var subscription = subscribe(function () {}, empty())
+
+    refute.same(null, subscription)
+    assert.isObject(subscription)
+    assert.isFunction(subscription.unsubscribe)
+
+    assert.same(undefined, subscription.unsubscribe())
+  })
+
+  it('should throw TypeError if subscriber not an object (or function)', function () {
     assert.exception(function () {
       subscribe(null, empty())
     }, function (e) { return e instanceof TypeError })


### PR DESCRIPTION
### Summary

Use object wrapping rather than the typeof check to determine if subscriber is valid. Correctly handles objects and functions and is compatible with how RxJS and zen-observable behave as they don’t distinguish between objects and functions. (issue #445)
