### PR TITLE
chore(deps): Update examples to use @most/hold 2.x

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -238,7 +238,7 @@ The observable must provide minimal draft ES observable compliance as per the [e
 
 The iterable can be an Array, Array-like, or anything that supports the [iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/iterable) or [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/The_Iterator_protocol), such as a [generator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*). Providing a finite iterable, such as an Array, creates a finite stream. Providing an infinite iterable, such as an infinite generator, creates an infinite stream.
 
-**Note:** `from` will fail fast by throwing a `TypeError` *synchronously* when passed a value that is not an `Iterable`, `Iterator`, or `Observable`.  This indicates an invalid use of `from`, which should be fixed/prevented rather than handled at runtime. 
+**Note:** `from` will fail fast by throwing a `TypeError` *synchronously* when passed a value that is not an `Iterable`, `Iterator`, or `Observable`.  This indicates an invalid use of `from`, which should be fixed/prevented rather than handled at runtime.
 
 ```js
 // Logs 1 2 3 4
@@ -1033,7 +1033,7 @@ Functional APIs allow for the highest degree of modularity via external packages
 If you prefer using fluent APIs, `thru` allows using those functional APIs in a fluent style.  For example:
 
 ```es6
-import hold from '@most/hold'
+import { hold } from '@most/hold'
 import { periodic } from 'most'
 
 periodic(10, 1)
@@ -1046,7 +1046,7 @@ periodic(10, 1)
 rather than mixing functional and fluent:
 
 ```es6
-import hold from '@most/hold'
+import { hold } from '@most/hold'
 import { periodic } from 'most'
 
 hold(periodic(10, 1)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "devDependencies": {
     "@most/eslint-config-most": "^1.0.3",
-    "@most/hold": "1.4.2",
+    "@most/hold": "^2.0.0",
     "babel-polyfill": "^6.20.0",
     "buba": "^4.0.1",
     "buster": "^0.7.18",


### PR DESCRIPTION
<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

Update markdown examples to use `@most/hold` 2.x

### Todo

- [x] Unit tests for new or changed APIs and/or functionality
- [x] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples

