### PR TITLE
fix(type-definitions): Scheduler method signatures

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -29,7 +29,7 @@ export interface ScheduledTask {
 export interface Scheduler {
   now(): number;
   asap(task: Task): ScheduledTask;
-  delay(task: Task): ScheduledTask;
+  delay(delay: number, task: Task): ScheduledTask;
   periodic(task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -30,7 +30,7 @@ export interface Scheduler {
   now(): number;
   asap(task: Task): ScheduledTask;
   delay(delay: number, task: Task): ScheduledTask;
-  periodic(task: Task): ScheduledTask;
+  periodic(period: number, task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;
   cancelAll(predicate: (task: Task) => boolean): void;


### PR DESCRIPTION
The type definition `Scheduler.delay(task)` was incorrect. I updated it to `Scheduler.delay(delay, task)`.