### PR TITLE
generic parameter default for Disposable<A>

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -36,7 +36,7 @@ export interface Scheduler {
   cancelAll(predicate: (task: Task) => boolean): void;
 }
 
-export interface Disposable<A> {
+export interface Disposable<A = any> {
   dispose(): void | Promise<A>;
 }
 

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -29,7 +29,7 @@ export interface ScheduledTask {
 export interface Scheduler {
   now(): number;
   asap(task: Task): ScheduledTask;
-  delay(task: Task): ScheduledTask;
+  delay(delay: number, task: Task): ScheduledTask;
   periodic(task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -30,7 +30,7 @@ export interface Scheduler {
   now(): number;
   asap(task: Task): ScheduledTask;
   delay(delay: number, task: Task): ScheduledTask;
-  periodic(task: Task): ScheduledTask;
+  periodic(period: number, task: Task): ScheduledTask;
   schedule(delay: number, period: number, task: Task): ScheduledTask;
   cancel(task: Task): void;
   cancelAll(predicate: (task: Task) => boolean): void;


### PR DESCRIPTION
`Disposable<A>` takes a generic type argument which is almost never used in practice. To eliminate the unnecessary specificity in most use cases, I've added a generic parameter default of `any`, which changes the definition to:

```ts
export interface Disposable<A = any> {
  dispose(): void | Promise<A>;
}
```
