### PR TITLE
docs(api): specify unit of delay

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1577,7 +1577,7 @@ In contrast to debounce, throttle simply drops events that occur more often than
 #### `stream.delay(delayTime) -> Stream`
 #### `most.delay(delayTime, stream) -> Stream`
 
-Timeshift a `stream` by `delayTime`.
+Timeshift a `stream` by `delayTime` in milliseconds.
 
 ```
 stream:          -a-b-c-d->


### PR DESCRIPTION
### Summary

I never remember if most tries to be smart and `delayTime` is in seconds, or if it's ms ...

This adds the unit on the delayTime argument of the delay operator in the api docs.
