### PR TITLE
Improve filter type definition

### DIFF
--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -137,6 +137,7 @@ export interface Stream<A> extends Source<A> {
   concat(s2: Stream<A>): Stream<A>;
   startWith(a: A): Stream<A>;
 
+  filter<B extends A>(p: (val: A) => val is B): Stream<B>;
   filter(p: (a: A) => boolean): Stream<A>;
   skipRepeats(): Stream<A>;
   skipRepeatsWith(eq: (a1: A, a2: A) => boolean): Stream<A>;
@@ -311,6 +312,10 @@ export function loop<A, B, S>(f: (seed: S, a: A) => SeedValue<S, B>, seed: S, s:
 export function concat<A>(s1: Stream<A>, s2: Stream<A>): Stream<A>;
 export function startWith<A>(a: A, s: Stream<A>): Stream<A>;
 
+export function filter<A, B extends A>(
+  p: (val: A) => val is B,
+  s: Stream<A>
+): Stream<B>;
 export function filter<A>(p: (a: A) => boolean, s: Stream<A>): Stream<A>;
 export function skipRepeats<A>(s: Stream<A>): Stream<A>;
 export function skipRepeatsWith<A>(eq: (a1: A, a2: A) => boolean, s: Stream<A>): Stream<A>;


### PR DESCRIPTION
### Summary

The filter from rxjs uses typeguards in order to infer the new type of a stream after a filter operation. This isn't in most, so I implemented it.

Example by what I mean:

```js
filter(isString, from([1, 2, 'hello']))
  .map(v => {}) // v at this point is inferred to be a string rather than string | number
```

I tried it out on my machine as a method of a stream and as a function. It works on both.

I don't think unit tests or documentation are necessary for this change, it falls back to the old typing if no type guard is found.

