### PR TITLE
Dispose the source disposable

### DIFF
--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -4,7 +4,6 @@
 
 import Stream from '../Stream'
 import Pipe from '../sink/Pipe'
-import * as dispose from '../disposable/dispose'
 import PropagateTask from '../scheduler/PropagateTask'
 import Map from '../fusion/Map'
 

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -110,7 +110,7 @@ DebounceSink.prototype.error = function (t, x) {
 
 DebounceSink.prototype.dispose = function () {
   this._clearTimer()
-  this.disposable.dispose()
+  return this.disposable.dispose()
 }
 
 DebounceSink.prototype._clearTimer = function () {

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -110,6 +110,7 @@ DebounceSink.prototype.error = function (t, x) {
 
 DebounceSink.prototype.dispose = function () {
   this._clearTimer()
+  this.disposable.dispose()
 }
 
 DebounceSink.prototype._clearTimer = function () {

--- a/src/combinator/limit.js
+++ b/src/combinator/limit.js
@@ -84,9 +84,7 @@ function DebounceSink (dt, source, sink, scheduler) {
   this.scheduler = scheduler
   this.value = void 0
   this.timer = null
-
-  var sourceDisposable = source.run(this, scheduler)
-  this.disposable = dispose.all([this, sourceDisposable])
+  this.disposable = source.run(this, scheduler)
 }
 
 DebounceSink.prototype.event = function (t, x) {

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -10,6 +10,9 @@ var take = require('../src/combinator/slice').take
 var fromArray = require('../src/source/fromArray').fromArray
 var core = require('../src/source/core')
 var Map = require('../src/fusion/Map').default
+var drain = require('../src/combinator/observe').drain
+var Stream = require('../src/Stream').default
+var FakeDisposeSource = require('./helper/FakeDisposeSource')
 
 var empty = core.empty
 var streamOf = core.of
@@ -94,6 +97,16 @@ describe('debounce', function () {
           { time: 7, value: 2 }
         ])
       })
+  })
+
+  it('should dispose', function () {
+    var dispose = this.spy()
+    var s = new Stream(new FakeDisposeSource(dispose, streamOf(sentinel).source))
+    var debounced = limit.debounce(1, s)
+
+    return drain(s).then(function () {
+      expect(dispose).toHaveBeenCalledOnce()
+    })
   })
 })
 

--- a/test/limit-test.js
+++ b/test/limit-test.js
@@ -104,7 +104,7 @@ describe('debounce', function () {
     var s = new Stream(new FakeDisposeSource(dispose, streamOf(sentinel).source))
     var debounced = limit.debounce(1, s)
 
-    return drain(s).then(function () {
+    return drain(debounced).then(function () {
       expect(dispose).toHaveBeenCalledOnce()
     })
   })


### PR DESCRIPTION
When disposing a debounce stream we also need to dispose the source disposable

<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

I was trying to use `debounce` in the following scenario

```
combine(...streams$)
    .debounce(1000)
    .chain(chainStream)
    .subscribe(observer);
```

But I soon realized that when I tried to dispose the above stream, it would ignore disposing the stream (source stream) that comes before the debounce.
### Todo

- [x] Unit tests for new or changed APIs and/or functionality
- [ ] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples

