### PR TITLE
feat(thru): Make thru parametric in its return type

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1022,13 +1022,15 @@ stream.loop((values, x) => {
 
 ### thru
 
-#### `stream.thru(transform) -> Stream`
+#### `stream.thru(transform) -> R`
 
-`transform(stream: Stream) -> Stream`
+`transform (stream: Stream<A>) -> R`
 
 Use a functional API in fluent style.
 
 Functional APIs allow for the highest degree of modularity via external packages, such as [`@most/hold`](https://github.com/mostjs/hold), *without the risks of modifying prototypes*.
+
+Note that the `transform` function may return any type (not just a Stream), and `.thru(transform)` will also return that type.
 
 If you prefer using fluent APIs, `thru` allows using those functional APIs in a fluent style.  For example:
 
@@ -1053,6 +1055,23 @@ hold(periodic(10, 1)
 	.take(5)
 	.scan((total, increment) => total + increment, 0))
 	.observe(x => console.log(x))
+```
+
+Note also that the function passed to `thru` is not restricted to returning a stream.  For example:
+
+```es6
+import { from } from 'most'
+
+const lastAsPromise = (stream) =>
+  stream.reduce((_, x) => x)
+
+// since lastAsPromise returns a Promise
+// stream.thru(lastAsPromise) *also* returns a Promise because
+
+// logs 3
+from([1, 2, 3])
+  .thru(lastAsPromise) // returns a Promise
+  .then(x => console.log(x))
 ```
 
 #### Multiple arguments

--- a/src/combinator/thru.js
+++ b/src/combinator/thru.js
@@ -1,4 +1,4 @@
-/** @license MIT License (c) copyright 2010-2016 original author or authors */
+/** @license MIT License (c) copyright 2010-2017 original author or authors */
 /** @author Brian Cavalier */
 /** @author John Hann */
 

--- a/test/combinator/thru-test.js
+++ b/test/combinator/thru-test.js
@@ -1,22 +1,20 @@
-/* global describe, it */
-require('buster').spec.expose()
-var expect = require('buster').expect
+import { spec, referee } from 'buster'
+const { describe, it } = spec
+const { assert } = referee
 
-var thru = require('../../src/combinator/thru').thru
+import { thru } from '../../src/combinator/thru'
 
 describe('thru', function () {
   it('should apply f to stream', function () {
-    var stream = {}
-    var expected = {}
-    function f (s) {
-      return expected
-    }
+    const stream = {}
+    const expected = {}
+    const f = s => expected
 
-    expect(thru(f, stream)).toBe(expected)
+    assert.same(expected, thru(f, stream))
   })
 
   it('should throw synchronously if f throws synchronously', function () {
-    var error = new Error()
+    const error = new Error()
     function f () {
       throw error
     }
@@ -24,7 +22,7 @@ describe('thru', function () {
     try {
       thru(f, {})
     } catch (e) {
-      expect(e).toBe(error)
+      assert.same(error, e)
     }
   })
 })

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -210,7 +210,7 @@ export interface Stream<A> extends Source<A> {
   recoverWith<B>(p: (a: B) => Stream<A>): Stream<A>;
   multicast(): Stream<A>;
 
-  thru<B>(transform: (stream: Stream<A>) => Stream<B>): Stream<B>;
+  thru<B>(transform: (stream: Stream<A>) => B): B;
 }
 
 declare interface DisposeFn {


### PR DESCRIPTION
### Summary

See https://github.com/cujojs/most/issues/471

Make `thru` parametric in its return type to admit functions that return something other than a Stream.

### Todo

- [x] Unit tests for new or changed APIs and/or functionality
- [x] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples
