### PR TITLE
Clean up readme types

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Most.js has a dependency on native Promises so a type definition for Promise mus
 <a href="https://github.com/fantasyland/fantasy-land"><img width="82" height="82" alt="Fantasy Land" src="https://raw.github.com/puffnfresh/fantasy-land/master/logo.png"></a>
 <a href="https://github.com/rpominov/static-land"><img width="131" height="82" src="https://raw.githubusercontent.com/rpominov/static-land/master/logo/logo.png" /></a>
 
-Most.js streams are [compatible with Promises/A+ and ES6 Promises](promises).  They also implement [Fantasy Land](https://github.com/fantasyland/fantasy-land) and [Static Land](https://github.com/rpominov/static-land) (via [`most-static-land`](https://github.com/mostjs-community/most-static-land)) `Monoid`, `Functor`, `Applicative`, and `Monad`.
+Most.js streams are [compatible with Promises/A+ and ES6 Promises](promises).  They also implement [Fantasy Land](https://github.com/fantasyland/fantasy-land) and [Static Land](https://github.com/rpominov/static-land) `Monoid` and `Monad`.
 
 ## Reactive Programming
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Most.js has a dependency on native Promises so a type definition for Promise mus
 <a href="https://github.com/fantasyland/fantasy-land"><img width="82" height="82" alt="Fantasy Land" src="https://raw.github.com/puffnfresh/fantasy-land/master/logo.png"></a>
 <a href="https://github.com/rpominov/static-land"><img width="131" height="82" src="https://raw.githubusercontent.com/rpominov/static-land/master/logo/logo.png" /></a>
 
-Most.js streams are [compatible with Promises/A+ and ES6 Promises](promises).  They also implement [Fantasy Land](https://github.com/fantasyland/fantasy-land) and [Static Land](https://github.com/rpominov/static-land) `Monoid` and `Monad`.
+Most.js streams are [compatible with Promises/A+ and ES6 Promises](promises).  They also implement [Fantasy Land](https://github.com/fantasyland/fantasy-land) and [Static Land](https://github.com/rpominov/static-land) `Semigroup`, `Monoid`, `Functor`, `Apply`, `Applicative`, `Chain` and `Monad`.
 
 ## Reactive Programming
 


### PR DESCRIPTION
### Summary
Most itself support and fantasy and static land. Also monad already includes functor and applicative interfaces according both spec