### PR TITLE
Throw error if handler is not present

### DIFF
--- a/src/observable/subscribe.js
+++ b/src/observable/subscribe.js
@@ -40,7 +40,7 @@ SubscribeObserver.prototype.end = function (t, x) {
         s.complete(x)
       }
     }).catch(function (e) {
-      throwError(e, s.error.bind(s), fatalError)
+      throwError(e, s, fatalError)
     })
   }
 }
@@ -49,7 +49,7 @@ SubscribeObserver.prototype.error = function (t, e) {
   var s = this.subscriber
   var fatalError = this.fatalError
   Promise.resolve(this.disposable.dispose()).then(function () {
-    throwError(e, s.error.bind(s), fatalError)
+    throwError(e, s, fatalError)
   })
 }
 
@@ -61,14 +61,14 @@ Subscription.prototype.unsubscribe = function () {
   this.disposable.dispose()
 }
 
-function throwError (e1, throw1, throw2) {
-  if (typeof throw1 === 'function') {
+function throwError (e1, subscriber, throwError) {
+  if (typeof subscriber.error === 'function') {
     try {
-      throw1(e1)
+      subscriber.error(e1)
     } catch (e2) {
-      throw2(e2)
+      throwError(e2)
     }
   } else {
-    throw2(e1)
+    throwError(e1)
   }
 }

--- a/src/observable/subscribe.js
+++ b/src/observable/subscribe.js
@@ -40,7 +40,7 @@ SubscribeObserver.prototype.end = function (t, x) {
         s.complete(x)
       }
     }).catch(function (e) {
-      throwError(e, s.error, fatalError)
+      throwError(e, s.error.bind(s), fatalError)
     })
   }
 }
@@ -49,7 +49,7 @@ SubscribeObserver.prototype.error = function (t, e) {
   var s = this.subscriber
   var fatalError = this.fatalError
   Promise.resolve(this.disposable.dispose()).then(function () {
-    throwError(e, s.error, fatalError)
+    throwError(e, s.error.bind(s), fatalError)
   })
 }
 

--- a/test/observable/subscribe-test.js
+++ b/test/observable/subscribe-test.js
@@ -172,5 +172,18 @@ describe('SubscribeObserver', function () {
         assert.same(error, e)
       })
     })
+
+    it('should not swallow error if handler is not present', () => {
+      var error = new Error()
+
+      return new Promise(function (resolve) {
+        var subscriber = {}
+
+        var so = new SubscribeObserver(resolve, subscriber, dispose.empty())
+        so.error(0, error)
+      }).then(function (e) {
+        assert.same(error, e)
+      })
+    })
   })
 })


### PR DESCRIPTION
### Summary

This example swallows errors
```js
const stream = most.throwError(1);
stream.subscribe({
  next: v => console.log(v)
});
```