### PR TITLE
Mention zero and foldable algebraic types

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,10 +17,10 @@ export { Stream }
 
 // Add of and empty to constructor for fantasy-land compat
 Stream.of = of
-Stream.empty = empty
+Stream.empty = Stream.zero = empty
 // Add from to constructor for ES Observable compat
 Stream.from = from
-export { of, of as just, empty, never, from, periodic }
+export { of, of as just, empty, empty as zero, never, from, periodic }
 
 // -----------------------------------------------------------------------
 // Draft ES Observable proposal interop
@@ -265,7 +265,7 @@ Stream.prototype.join = function () {
 import { continueWith } from './combinator/continueWith'
 
 // @deprecated flatMapEnd, use continueWith instead
-export { continueWith, continueWith as flatMapEnd }
+export { continueWith, continueWith as alt, continueWith as flatMapEnd }
 
 /**
  * Map the end event to a new stream, and begin emitting its values.
@@ -278,6 +278,7 @@ Stream.prototype.continueWith = function (f) {
   return continueWith(f, this)
 }
 
+Stream.prototype.alt = Stream.prototype.continueWith
 // @deprecated use continueWith instead
 Stream.prototype.flatMapEnd = Stream.prototype.continueWith
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -77,6 +77,7 @@ declare export class Stream<A> {
   ap<B, C>(fs: Stream<(a: A) => B>): Stream<C>;
 
   continueWith(f: (a: any) => Stream<A>): Stream<A>;
+  alt(f: () => Stream<A>): Stream<A>;
   concatMap<B>(f: (a: A) => Stream<B>): Stream<B>;
   mergeConcurrently<B>(concurrency: number): Stream<B>;
   merge(...ss: Array<Stream<A>>): Stream<A>;
@@ -210,6 +211,7 @@ declare export class Stream<A> {
 declare export function just<A>(a: A): Stream<A>;
 declare export function of<A>(a: A): Stream<A>;
 declare export function empty(): Stream<any>;
+declare export function zero(): Stream<any>;
 declare export function never(): Stream<any>;
 declare export function from<A>(as: A[] | Iterable<A> | Observable<A>): Stream<A>;
 declare export function periodic<A>(period: number, a?: A): Stream<A>;
@@ -237,6 +239,7 @@ declare export function join<A>(s: Stream<Stream<A>>): Stream<A>;
 declare export function switchLatest<A>(s: Stream<Stream<A>>): Stream<A>;
 
 declare export function continueWith<A>(f: (a: any) => Stream<A>, s: Stream<A>): Stream<A>;
+declare export function alt<A>(f: () => Stream<A>, s: Stream<A>): Stream<A>;
 declare export function concatMap<A, B>(f: (a: A) => Stream<B>, s: Stream<A>): Stream<B>;
 declare export function mergeConcurrently<A>(concurrency: number, s: Stream<Stream<A>>): Stream<A>;
 

--- a/test/alt-plus-test.js
+++ b/test/alt-plus-test.js
@@ -1,0 +1,58 @@
+/* global describe, it */
+require('buster').spec.expose()
+const { expect } = require('buster')
+
+const most = require('../src')
+
+const reduceOne = s => s.reduce((acc, x) => [...acc, x], [])
+
+const reduceTwo = (s1, s2) => Promise.all([reduceOne(s1), reduceOne(s2)])
+
+describe('Alt', () => {
+  it('should satisfy associativity', () => {
+    const s1 = most.of(1).continueWith(() => most.of(2)).continueWith(() => most.of(3))
+    const s2 = most.of(1).continueWith(() => most.of(2).continueWith(() => most.of(3)))
+
+    return reduceTwo(s1, s2).then(([r1, r2]) => {
+      expect(r1).toEqual(r2)
+    })
+  })
+
+  it('should satisfy distributivity', () => {
+    const f = x => x + 10
+    const s1 = most.of(1).continueWith(() => most.of(2)).map(f)
+    const s2 = most.of(1).map(f).continueWith(() => most.of(2).map(f))
+
+    return reduceTwo(s1, s2).then(([r1, r2]) => {
+      expect(r1).toEqual(r2)
+    })
+  })
+})
+
+describe('Plus', () => {
+  it('should satisfy right identity', () => {
+    const s = most.of(1).continueWith(() => most.zero())
+
+    return reduceOne(s).then(r => {
+      expect(r).toEqual([1])
+    })
+  })
+
+  it('should satisfy left identity', () => {
+    const s = most.zero().continueWith(() => most.of(1))
+
+    return reduceOne(s).then(r => {
+      expect(r).toEqual([1])
+    })
+  })
+
+  it('should satisfy annihilation', () => {
+    const f = x => x + 10
+    const s1 = most.zero().map(f)
+    const s2 = most.zero()
+
+    return reduceTwo(s1, s2).then(([r1, r2]) => {
+      expect(r1).toEqual(r2)
+    })
+  })
+})

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -12,6 +12,13 @@ describe('just', () => {
   })
 })
 
+describe('zero', () => {
+  it('should be an alias for empty', () => {
+    assert.isFunction(most.zero)
+    assert.same(most.zero, most.empty)
+  })
+})
+
 describe('chain', () => {
   it('should be an alias for flatMap', () => {
     assert.isFunction(most.chain)
@@ -41,6 +48,14 @@ describe('skipUntil', () => {
     assert.isFunction(most.skipUntil)
     assert.same(most.skipUntil, most.since)
     assert.same(most.Stream.prototype.skipUntil, most.Stream.prototype.since)
+  })
+})
+
+describe('alt', () => {
+  it('should be an alias for continueWith', () => {
+    assert.isFunction(most.alt)
+    assert.same(most.alt, most.continueWith)
+    assert.same(most.Stream.prototype.alt, most.Stream.prototype.continueWith)
   })
 })
 

--- a/type-definitions/most-flow-test.js
+++ b/type-definitions/most-flow-test.js
@@ -1,6 +1,12 @@
 // @flow
 
-import { just, subscribe } from '../src'
+import { just, subscribe, empty, zero, continueWith, alt } from '../src'
+
+class T1 {}
+class T2 {}
+
+var v1 = new T1
+var v2 = new T2
 
 subscribe({}, just(1))
 subscribe({ next: d => { (d: number) } }, just(1))
@@ -20,3 +26,33 @@ subscribe({ next: d => { (d: string) } }, just(1))
 subscribe({ error: err => { (err: string) } }, just(1))
 // $ExpectError
 unsubscribe(1)
+
+empty().take(1)
+zero().take(1)
+// $ExpectError
+empty(1)
+// $ExpectError
+zero(1)
+
+// test type inference
+continueWith(() => just(v2), just(v1)).observe((d: T1 | T2) => {})
+alt(() => just(v2), just(v1)).observe((d: T1 | T2) => {})
+just(v1).continueWith(() => just(v2)).observe((d: T1 | T2) => {})
+just(v1).alt(() => just(v2)).observe((d: T1 | T2) => {})
+// test existence of function parameter
+continueWith((d: T1) => just(v2), just(v1))
+just(v1).continueWith((d: T1) => just(v2))
+// Test missing parameter
+// $ExpectError
+alt((d: T1) => just(v2), just(v1))
+// $ExpectError
+just(v1).alt((d: T1) => just(v2))
+// Test returned value
+// $ExpectError
+alt(() => 1, just(v1))
+// $ExpectError
+continueWith(() => 1, just(v1))
+// $ExpectError
+just(v1).alt(() => 1)
+// $ExpectError
+just(v1).continueWith(() => 1)


### PR DESCRIPTION
[Plus](https://github.com/rpominov/static-land/blob/master/docs/spec.md#plus)::zero is implemented via `empty`, `never` methods
Not sure about `scan`, but `reduce` looks like [Foldable](https://github.com/rpominov/static-land/blob/master/docs/spec.md#foldable)::reduce

We can add some examples with laws around these types.