### PR TITLE
Allow omitting properties of subscriber

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]
+suppress_comment=\\(.\\|\n\\)*\\$ExpectError

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   "dependencies": {
     "@most/multicast": "^1.2.5",
     "@most/prelude": "^1.4.0",
+    "flow-bin": "^0.53.1",
     "symbol-observable": "^1.0.2"
   }
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -48,10 +48,10 @@ export type Observable<A> = {
 }
 
 export type Subscriber<A> = {
-  next(value: A): void;
-  error(err: Error): void;
+  next?: (value: A) => void;
+  error?: (err: Error) => void;
   // complete value parameter is deprecated
-  complete(value?: A): void;
+  complete?: (value?: A) => void;
 }
 
 export type Subscription<A> = {

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -48,10 +48,10 @@ export type Observable<A> = {
 }
 
 export type Subscriber<A> = {
-  next?: (value: A) => void;
-  error?: (err: Error) => void;
+  +next?: (value: A) => void;
+  +error?: (err: Error) => void;
   // complete value parameter is deprecated
-  complete?: (value?: A) => void;
+  +complete?: (value?: A) => void;
 }
 
 export type Subscription<A> = {

--- a/type-definitions/most-flow-test.js
+++ b/type-definitions/most-flow-test.js
@@ -6,10 +6,10 @@ subscribe({}, just(1))
 subscribe({ next: d => { (d: number) } }, just(1))
 subscribe({ error: err => { (err: Error) } }, just(1))
 subscribe({ complete: () => {} }, just(1))
-const { unsubscribe } = subscribe({
-  next: () => {},
-  error: () => {},
-  complete: () => {}
+const { unsubscribe } = subscribe(new class {
+  next() {};
+  error() {};
+  complete() {};
 }, just(1))
 unsubscribe()
 // $ExpectError

--- a/type-definitions/most-flow-test.js
+++ b/type-definitions/most-flow-test.js
@@ -1,0 +1,22 @@
+// @flow
+
+import { just, subscribe } from '../src'
+
+subscribe({}, just(1))
+subscribe({ next: d => { (d: number) } }, just(1))
+subscribe({ error: err => { (err: Error) } }, just(1))
+subscribe({ complete: () => {} }, just(1))
+const { unsubscribe } = subscribe({
+  next: () => {},
+  error: () => {},
+  complete: () => {}
+}, just(1))
+unsubscribe()
+// $ExpectError
+subscribe()
+// $ExpectError
+subscribe({ next: d => { (d: string) } }, just(1))
+// $ExpectError
+subscribe({ error: err => { (err: string) } }, just(1))
+// $ExpectError
+unsubscribe(1)


### PR DESCRIPTION
### Summary

According [spec](https://github.com/tc39/proposal-observable#observer) all props of subscriber can be omitted. Also I added first test case for subscriber and would like to improve coverage step by step.