### PR TITLE
fix(delay): Fix delay dispose

### DIFF
--- a/src/combinator/delay.js
+++ b/src/combinator/delay.js
@@ -35,8 +35,8 @@ function DelaySink (dt, sink, scheduler) {
 
 DelaySink.prototype.dispose = function () {
   var self = this
-  this.scheduler.cancelAll(function (task) {
-    return task.sink === self.sink
+  this.scheduler.cancelAll(function (scheduledTask) {
+    return scheduledTask.task.sink === self.sink
   })
 }
 

--- a/test/delay-test.js
+++ b/test/delay-test.js
@@ -1,23 +1,19 @@
-/* global describe, it */
-require('buster').spec.expose()
-var expect = require('buster').expect
+import { spec, referee } from 'buster'
+const { describe, it } = spec
+const { assert } = referee
 
-var delay = require('../src/combinator/delay').delay
-var streamOf = require('../src/source/core').of
+import { delay } from '../src/combinator/delay'
+import { collectEvents, makeEvents, ticks } from './helper/testEnv'
 
-var te = require('./helper/testEnv')
-
-var sentinel = { value: 'sentinel' }
-
-describe('delay', function () {
-  it('should delay events by delayTime', function () {
-    var dt = 1
-    var s = delay(dt, streamOf(sentinel))
-
-    return te.collectEvents(s, te.ticks(dt + 1)).then(function (events) {
-      expect(events.length).toBe(1)
-      expect(events[0].time).toBe(dt)
-      expect(events[0].value).toBe(sentinel)
-    })
+describe('delay', () => {
+  it('should delay events by delayTime', () => {
+    const n = 2
+    const dt = 1
+    const s = delay(dt, makeEvents(dt, n))
+    return collectEvents(s, ticks(n + dt)).then(events =>
+      assert.equals(events, [
+        { time: 1, value: 0 },
+        { time: 2, value: 1 }
+      ]))
   })
 })

--- a/test/delay-test.js
+++ b/test/delay-test.js
@@ -3,7 +3,13 @@ const { describe, it } = spec
 const { assert } = referee
 
 import { delay } from '../src/combinator/delay'
-import { collectEvents, makeEvents, ticks } from './helper/testEnv'
+import { map, tap } from '../src/combinator/transform'
+import { switchLatest } from '../src/combinator/switch'
+import { continueWith } from '../src/combinator/continueWith'
+import { take } from '../src/combinator/slice'
+import { of as just } from '../src/source/core'
+import { periodic } from '../src/source/periodic'
+import { collectEvents, makeEvents, ticks, at } from './helper/testEnv'
 
 describe('delay', () => {
   it('should delay events by delayTime', () => {
@@ -15,5 +21,17 @@ describe('delay', () => {
         { time: 1, value: 0 },
         { time: 2, value: 1 }
       ]))
+  })
+
+  it('should dispose pending tasks', () => {
+    // Test derived from example:
+    // https://github.com/cujojs/most/issues/488
+    let count = 0
+    const toDelay = x => tap(() => count++, delay(10, just(x)))
+    const s0 = switchLatest(map(toDelay, take(2, periodic(1, 1))))
+    const s1 = continueWith(() => at(100, 0), s0)
+
+    return collectEvents(s1, ticks(30)).then(() =>
+      assert.equals(1, count))
   })
 })

--- a/test/helper/testEnv.js
+++ b/test/helper/testEnv.js
@@ -18,6 +18,7 @@ exports.collectEvents = collectEvents
 exports.drain = drain
 exports.atTimes = atTimes
 exports.makeEvents = makeEvents
+exports.at = at
 
 function TestEnvironment (timer, scheduler) {
   this.timer = timer
@@ -61,6 +62,10 @@ function makeEvents (dt, n) {
     events[i] = { time: (i * dt), value: i }
   }
   return atTimes(events)
+}
+
+function at (time, value) {
+  return atTimes([{ time: time, value: value }])
 }
 
 function atTimes (array) {


### PR DESCRIPTION
<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

Fix bug in delay that caused pending delayed events to be propagated after dispose.

Fix #488

### Todo

- [x] Unit tests for new or changed APIs and/or functionality
  - So far it's has proven difficult to write a *simple* unit test for this.  I may opt for a more complex test to get this merged.

