### PR TITLE
fix(types): Added flow type definitions for await and awaitPromises.

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -154,6 +154,9 @@ declare export class Stream<A> {
   timestamp(): Stream<TimeValue<A>>;
   delay(dt: number): Stream<A>;
 
+  await<B>(): Stream<B>;
+  awaitPromises<B>(): Stream<B>;
+
   sample<B, C, R>(
     fn: (b: B, c: C) => R,
     b: Stream<B>,


### PR DESCRIPTION
<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

Using `most` with function chaining doesn't type check using [`flow`](https://flow.org) when using `awaitPromises` with the following error: `Cannot call fromEvent(...).map(...).awaitPromises because property awaitPromises is missing in Stream`. The fix adds a type definition for the `await` and `awaitPromises` property and allows flow to type check.

I saw that the original type definitions were removed in #494. From my understanding flow doesn't require a type definition for `this`. But since I'm fairly new to flow I might be missing something. I use flow version 0.73.