### PR TITLE
Streams became covariant

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -5,7 +5,7 @@ declare type TimeValue<V> = { time: number, value: V };
 
 declare type CreateGenerator<A> = (...args: Array<any>) => Generator<A|Promise<A>, any, any>;
 
-export type Sink<A> = {
+export type Sink<+A> = {
   event(time: number, value: A): void;
   // end value parameter is deprecated
   end(time: number, value?: A): void;


### PR DESCRIPTION
I want to downgrade a type sometimes.

```js
declare var string$: Stream<string>;
const stringNumber$ = (string$: Stream<number | string>).startWith(0);
```

Streams are read-only, so there is no need to leave them invariant.