### PR TITLE
Authorise different returned type for recoverWith

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -198,7 +198,7 @@ declare export class Stream<A> {
     e: Stream<E>
   ): Stream<R>;
 
-  recoverWith<B>(p: (a: B) => Stream<A>): Stream<A>;
+  recoverWith<B, C>(p: (a: B) => Stream<C>): Stream<A | C>;
   multicast(): Stream<A>;
 
   thru<B>(transform: (stream: Stream<A>) => B): B;
@@ -380,7 +380,7 @@ declare export function zip<A, B, C, D, E, R>(
   e: Stream<E>
 ): Stream<R>;
 
-declare export function recoverWith<A, B>(p: (a: B) => Stream<A>, s: Stream<A>): Stream<A>;
+declare export function recoverWith<A, B, C>(p: (a: B) => Stream<C>, s: Stream<A>): Stream<A | C>;
 declare export function throwError(e: Error): Stream<any>;
 
 declare export function multicast<A>(s: Stream<A>): Stream<A>;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -204,7 +204,7 @@ export interface Stream<A> extends Source<A> {
     e: Stream<E>
   ): Stream<R>;
 
-  recoverWith<B, C>(p: (a: B) => Stream<C>): Stream<C>;
+  recoverWith<B, C>(p: (a: B) => Stream<C>): Stream<A | C>;
   multicast(): Stream<A>;
 
   thru<B>(transform: (stream: Stream<A>) => B): B;
@@ -399,7 +399,7 @@ export function zip<A, B, C, D, E, R>(
   e: Stream<E>
 ): Stream<R>;
 
-export function recoverWith<A, B, C>(p: (a: B) => Stream<C>, s: Stream<A>): Stream<C>;
+export function recoverWith<A, B, C>(p: (a: B) => Stream<C>, s: Stream<A>): Stream<A | C>;
 export function throwError(e: Error): Stream<any>;
 
 export function multicast<A>(s: Stream<A>): Stream<A>;

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -204,7 +204,7 @@ export interface Stream<A> extends Source<A> {
     e: Stream<E>
   ): Stream<R>;
 
-  recoverWith<B>(p: (a: B) => Stream<A>): Stream<A>;
+  recoverWith<B, C>(p: (a: B) => Stream<C>): Stream<C>;
   multicast(): Stream<A>;
 
   thru<B>(transform: (stream: Stream<A>) => B): B;
@@ -399,7 +399,7 @@ export function zip<A, B, C, D, E, R>(
   e: Stream<E>
 ): Stream<R>;
 
-export function recoverWith<A, B>(p: (a: B) => Stream<A>, s: Stream<A>): Stream<A>;
+export function recoverWith<A, B, C>(p: (a: B) => Stream<C>, s: Stream<A>): Stream<C>;
 export function throwError(e: Error): Stream<any>;
 
 export function multicast<A>(s: Stream<A>): Stream<A>;


### PR DESCRIPTION
### Summary
Hi folks,
Currently the TS definitions of `recoverWith` expect the recovered stream to be of the same type of the one that errors. This feels off, since we'll often see patterns when recovering from error could for instance mean that we want a type signalling the error. This is especially true if you use a union of returned value, mapping to one of the values will prevent you to recover with another one.

For instance in my case, using `redux-most`:

```js
type Action =
  | FetchSuccess
  | FetchFailure

const stream: Stream<Action> =
  most
      .fromPromise(fetchData())
      .map(response =>fetchSuccess(response.data))
      .recoverWith((error: Error) => most.of(fetchError(error)))
)
```

This will error, stating that `Stream<FetchFailure>` (returned by `fetchError`) is incompatible with `Stream<FetchSucess>` (returned by `fetchSuccess`). But in my case, what matters is that both are compatible with `Stream<Action>`. I can temporarily fix this by annotating `.map((response): Action =>fetchSuccess(response.data))`, but that should probably not be necessary.

I've seen that the typings seems to be the same in `@most/core`, so if you'd want me to also update them, let me know.

I didn't see any types tests, and the `recoverWith` don't say anything about the type of the returned stream, so I don't think that should update anything else but the definitions file.

### Todo

- [X] Unit tests for new or changed APIs and/or functionality
- [X] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples

