### PR TITLE
Update Travis node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "latest"
+  - "node"
   - "lts/*"
 env:
   - CXX=g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 sudo: false
 node_js:
-  - "8"
-  - "6"
+  - "latest"
+  - "lts/*"
 env:
   - CXX=g++-4.8
 branches:
   only:
     - master
-    - /^greenkeeper/.*$/


### PR DESCRIPTION
### Summary

They were behind and manually updating is annoying.  Switch to latest + lts as per [Travis docs](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions).
