### PR TITLE
Explicitly prevent propagation after awaitPromises dispose

### DIFF
--- a/src/combinator/promises.js
+++ b/src/combinator/promises.js
@@ -33,27 +33,36 @@ function Await (source) {
 }
 
 Await.prototype.run = function (sink, scheduler) {
-  return this.source.run(new AwaitSink(sink, scheduler), scheduler)
+  return new AwaitSink(this.source, sink, scheduler)
 }
 
-function AwaitSink (sink, scheduler) {
+function AwaitSink (source, sink, scheduler) {
   this.sink = sink
   this.scheduler = scheduler
   this.queue = Promise.resolve()
+  this.disposable = source.run(this, scheduler)
+  this.active = true
   var self = this
 
   // Pre-create closures, to avoid creating them per event
   this._eventBound = function (x) {
+    if (!self.active) return
     self.sink.event(self.scheduler.now(), x)
   }
 
   this._endBound = function (x) {
+    if (!self.active) return
     self.sink.end(self.scheduler.now(), x)
   }
 
   this._errorBound = function (e) {
     self.sink.error(self.scheduler.now(), e)
   }
+}
+
+AwaitSink.prototype.dispose = function () {
+  this.active = false
+  return this.disposable.dispose()
 }
 
 AwaitSink.prototype.event = function (t, promise) {

--- a/test/combinator/promises-test.js
+++ b/test/combinator/promises-test.js
@@ -43,6 +43,22 @@ describe('await', function () {
       expect(spy).toHaveBeenCalledOnce()
     })
   })
+
+  it('should not propagate after dispose', function () {
+    var spy = this.spy()
+
+    return promises
+      .fromPromise(new Promise(resolve => setTimeout(resolve, 1)))
+      .tap(spy)
+      .merge(streamOf())
+      .take(1)
+      .drain()
+      .then(() => {
+        return new Promise(resolve => setTimeout(resolve, 1))
+      }).then(() => {
+        expect(spy).not.toHaveBeenCalled()
+      })
+  })
 })
 
 describe('fromPromise', function () {


### PR DESCRIPTION
### Summary

Fix #534 

Explicitly prevent event propagation after dispose.

### Todo

- [x] Unit tests for new or changed APIs and/or functionality

