### PR TITLE
Update typescript typings for .sample()

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1311,7 +1311,7 @@ See [combine](#combine) for more details.
 #### `sampler.sample(f, ...streams) -> Stream`
 #### `most.sample(f, sampler, ...streams) -> Stream`
 
-Create a new stream by combining sampled values from many input streams.
+Create a new stream by combining sampled values from one or more input streams.
 
 ```
 s1:                          -1-----2-----3->

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -160,6 +160,10 @@ export interface Stream<A> extends Source<A> {
   await<B>(this: Stream<Promise<B>>): Stream<B>;
   awaitPromises<B>(this: Stream<Promise<B>>): Stream<B>;
 
+  sample<B, R>(
+    fn: (b: B) => R,
+    b: Stream<B>,
+  ): Stream<R>;
   sample<B, C, R>(
     fn: (b: B, c: C) => R,
     b: Stream<B>,
@@ -339,6 +343,11 @@ export function fromPromise<A>(p: Promise<A>): Stream<A>;
 export function await<A>(s: Stream<Promise<A>>): Stream<A>;
 export function awaitPromises<A>(s: Stream<Promise<A>>): Stream<A>;
 
+export function sample<A, R>(
+  fn: (a: A) => R,
+  sampler: Stream<any>,
+  a: Stream<A>,
+): Stream<R>;
 export function sample<A, B, R>(
   fn: (a: A, b: B) => R,
   sampler: Stream<any>,


### PR DESCRIPTION
## Summary

Update typescript types to support the case of one `value$` argument for `.sample()`. It is a bit unclear in the documentation that this is supported as well but `.sampleWith()` hints about it: 

![image](https://user-images.githubusercontent.com/564350/79956662-bbd1f180-8480-11ea-9821-d69da59cec4b.png)



### Todo

- [x] Unit tests for new or changed APIs and/or functionality
  _No new functionality.._
- [x] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples
  _Just a simple change of wording._

### Mapped types instead?

Would it be preferable to change to use [mapped types](https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types) where possible for all the instances where we have overloaded types because of variable number of arguments? Then we could support an arbitrary number of arguments without having to resort to overloads.

Mapped types has been around since TS 2.1. Will possibly need the improvements to rest/spread types that came later though (3.2). [might be unrelated to my point](https://stackoverflow.com/questions/51189388/typescript-spread-types-may-only-be-created-from-object-types)

#### Example implementation

```typescript
sample<B extends unknown[], R>(
  fn: (...b: B) => R,
  ...b: { [T in keyof B]: Stream<B[T]> }
): Stream<R>;
```

Could also have a helper type to box elements in all the functions that will need to implement this:

```typescript
type StreamBoxed<T> = { [K in keyof T]: Stream<T[K]> };
```
