### PR TITLE
Fix build by using require for new cjs deps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ import * as base from '@most/prelude'
 import { of, empty, never } from './source/core'
 import { from } from './source/from'
 import { periodic } from './source/periodic'
-const getPolyfill = require('globalthis').getPolyfill
-const provideSymbolObservable = require('symbol-observable/ponyfill')
+const getGlobalThis = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill').default
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ import * as base from '@most/prelude'
 import { of, empty, never } from './source/core'
 import { from } from './source/from'
 import { periodic } from './source/periodic'
-import provideSymbolObservable from 'symbol-observable/ponyfill'
-import { getPolyfill as getGlobalThis } from 'globalthis'
+const getPolyfill = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill')
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 

--- a/src/observable/getObservable.js
+++ b/src/observable/getObservable.js
@@ -2,8 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-const getPolyfill = require('globalthis').getPolyfill
-const provideSymbolObservable = require('symbol-observable/ponyfill')
+const getGlobalThis = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill').default
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 

--- a/src/observable/getObservable.js
+++ b/src/observable/getObservable.js
@@ -2,8 +2,8 @@
 /** @author Brian Cavalier */
 /** @author John Hann */
 
-import provideSymbolObservable from 'symbol-observable/ponyfill'
-import { getPolyfill as getGlobalThis } from 'globalthis'
+const getPolyfill = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill')
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -1,8 +1,8 @@
 import { spec, referee } from 'buster'
 
 import * as most from '../src/index'
-const getPolyfill = require('globalthis').getPolyfill
-const provideSymbolObservable = require('symbol-observable/ponyfill')
+const getGlobalThis = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill').default
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 

--- a/test/most-test.js
+++ b/test/most-test.js
@@ -1,8 +1,8 @@
 import { spec, referee } from 'buster'
 
 import * as most from '../src/index'
-import provideSymbolObservable from 'symbol-observable/ponyfill'
-import { getPolyfill as getGlobalThis } from 'globalthis'
+const getPolyfill = require('globalthis').getPolyfill
+const provideSymbolObservable = require('symbol-observable/ponyfill')
 
 const symbolObservable = provideSymbolObservable(getGlobalThis())
 


### PR DESCRIPTION
<!-- Thank you for helping us to improve most.js!  Please provide as much information as possible below -->

### Summary

Fix build by using require for new cjs deps after https://github.com/cujojs/most/pull/541

It's a bummer, but our antiquated build setup is failing because it can't handle some kinds of CommonJS / ES module interop.  This is the simplest short term fix I could get working.  Here's what `npm run build` says:

<img width="830" alt="Screen Shot 2020-10-07 at 6 27 47 PM" src="https://user-images.githubusercontent.com/90518/95394742-1b0aad80-08cb-11eb-93ea-04476e31bd4e.png">

After this change:

<img width="564" alt="Screen Shot 2020-10-07 at 6 30 25 PM" src="https://user-images.githubusercontent.com/90518/95394847-4e4d3c80-08cb-11eb-9c11-ffd22e033819.png">

