### PR TITLE
Make subscribe callbacks optional in typings

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1160,18 +1160,18 @@ The returned promise will fulfill after all the events have been consumed, or wi
 
 #### `stream.subscribe(Observer) -> Subscription`
 
-Draft ES Observable compatible subscribe.  Start consuming events from `stream` by providing an [Observer object](https://github.com/zenparsing/es-observable#observer).
+Draft ES Observable compatible subscribe.  Start consuming events from `stream` by providing an [Observer object](https://github.com/zenparsing/es-observable#observer). All methods on `Observer` are optional.
 
 <!-- skip-example -->
 ```js
 type Observer = {
   // Receives the next value in the sequence
-  next(value) => void
+  next?(value) => void
   // Receives the sequence error
-  error(errorValue) => void
+  error?(errorValue) => void
   // Receives the sequence completion signal
   // The completionValue parameter is deprecated
-  complete(completionValue) => void
+  complete?(completionValue) => void
 }
 ```
 

--- a/type-definitions/most.d.ts
+++ b/type-definitions/most.d.ts
@@ -49,10 +49,10 @@ export interface Observable<A> {
 }
 
 export interface Subscriber<A> {
-  next(value: A): void;
-  error(err: Error): void;
+  next?(value: A): void;
+  error?(err: Error): void;
   // complete value parameter is deprecated
-  complete(value?: A): void;
+  complete?(value?: A): void;
 }
 
 export interface Subscription<A> {


### PR DESCRIPTION
### Summary

Update docs and typescript typings to reflect that methods on the `Observer` all are optional.

Here is what is linked in the docs regarding the `Observer`: https://github.com/tc39/proposal-observable#observer

Flow types seem to be correct already.

https://github.com/cujojs/most/blob/bfed148f1bfd8bc06a972a2cb17599371d8da52f/src/index.js.flow#L50-L55


### Todo

- [ ] ~Unit tests for new or changed APIs and/or functionality~
- [x] [Documentation](https://github.com/cujojs/most/blob/master/docs/api.md), including examples
